### PR TITLE
Restore `./circleci` configurations for our new CircleCI OAUTH organization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
             services/server/.* run-build-server true
             packages/.* run-build-packages true
           # Compare against the last build of the branch not the default "main" branch
-          base-revision: HEAD~1
+          base-revision: << pipeline.git.base_revision >>
           config-path: .circleci/continue_config.yml
   tagged_build_and_publish: # Triggered by a tag push. Runs separately for each tag.
     jobs:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -294,8 +294,7 @@ jobs:
       - run:
           name: create lcov reports
           command: npx lerna run cov:lcov
-      - codecov/upload:
-          slug: "argotorg/sourcify"
+      - codecov/upload
   monitor-e2e-sepolia:
     <<: *monitor-e2e-base
     environment:

--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -64,8 +64,7 @@ jobs:
       - run:
           name: create lcov reports
           command: npx lerna run cov:lcov
-      - codecov/upload:
-          slug: "argotorg/sourcify"
+      - codecov/upload
     resource_class: large
   test-new-chain:
     docker:


### PR DESCRIPTION
This morning we created a new CircleCI organization using a different auth method than OAUTH. This caused several problems:
- there is no `pipeline.git.base_version` support
- the organization slug is `circleci/2bWbncbTSPHJDSWS2B9PoE` instead of `argotorg`, causing the codecov CircleCI orb to fail
- **Most importantly**: we cannot enable CircleCI for external PRs

This PR rolls back some changing we had to do in the `./circleci` configurations so we can support the new CircleCI OAUTH account we'll create soon.