### PR TITLE
Use signature_type_enum for signature_type in db migrations

### DIFF
--- a/services/database/migrations/20250828092603_add_signature_tables.sql
+++ b/services/database/migrations/20250828092603_add_signature_tables.sql
@@ -1,5 +1,7 @@
 -- migrate:up
 
+CREATE TYPE signature_type_enum AS ENUM ('function','event','error','constructor');
+
 /*
     The `signatures` table stores signature information for compiled_contracts.
     It includes each signature in text and its keccak hash.
@@ -15,7 +17,7 @@ CREATE TABLE signatures (
   signature VARCHAR NOT NULL,
 
   /* type of signature: function, event, error, constructor */
-  signature_type VARCHAR NOT NULL CHECK (signature_type IN ('function','event','error','constructor')),
+  signature_type signature_type_enum NOT NULL,
 
   /* timestamps */
   created_at timestamptz NOT NULL DEFAULT NOW(),
@@ -53,5 +55,6 @@ CREATE INDEX compiled_contracts_signatures_compilation_idx ON compiled_contracts
 
 -- migrate:down
 
-DROP TABLE compiled_contracts_signatures;
-DROP TABLE signatures;
+DROP TABLE IF EXISTS compiled_contracts_signatures;
+DROP TABLE IF EXISTS signatures;
+DROP TYPE IF EXISTS signature_type_enum;

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,4 +1,4 @@
-\restrict sJLcxaHYPMP28Leh0GKIaLP8htazg5uukakP8yabITtnQnY2bDLWjqTbU9pmxvH
+\restrict kgmY5Es1RqaV2ek1n2W1DYtdjrChsTn3Lku4HCOmWiEIMmK4Y1uY24lNTQUygKe
 
 -- Dumped from database version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
 -- Dumped by pg_dump version 16.10 (Ubuntu 16.10-1.pgdg24.04+1)
@@ -26,6 +26,18 @@ CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
 --
 
 COMMENT ON EXTENSION pgcrypto IS 'cryptographic functions';
+
+
+--
+-- Name: signature_type_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.signature_type_enum AS ENUM (
+    'function',
+    'event',
+    'error',
+    'constructor'
+);
 
 
 --
@@ -991,10 +1003,9 @@ CREATE TABLE public.signatures (
     signature_hash_32 bytea NOT NULL,
     signature_hash_4 bytea GENERATED ALWAYS AS (SUBSTRING(signature_hash_32 FROM 1 FOR 4)) STORED,
     signature character varying NOT NULL,
-    signature_type character varying NOT NULL,
+    signature_type public.signature_type_enum NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    CONSTRAINT signatures_signature_type_check CHECK (((signature_type)::text = ANY ((ARRAY['function'::character varying, 'event'::character varying, 'error'::character varying, 'constructor'::character varying])::text[])))
+    updated_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
 
@@ -1995,7 +2006,7 @@ ALTER TABLE ONLY public.verified_contracts
 -- PostgreSQL database dump complete
 --
 
-\unrestrict sJLcxaHYPMP28Leh0GKIaLP8htazg5uukakP8yabITtnQnY2bDLWjqTbU9pmxvH
+\unrestrict kgmY5Es1RqaV2ek1n2W1DYtdjrChsTn3Lku4HCOmWiEIMmK4Y1uY24lNTQUygKe
 
 
 --


### PR DESCRIPTION
Related to #2316 

Should be more efficient than the previous approach. Will again reapply the migration on staging after merging.