### PR TITLE
Optimize signature stats query

### DIFF
--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -785,16 +785,16 @@ ${
     );
   }
 
-  async getSignatureCountByType(
-    signatureType: Tables.CompiledContractsSignatures["signature_type"],
-    poolClient?: PoolClient,
-  ): Promise<QueryResult<{ count: string }>> {
+  async getSignatureCounts(poolClient?: PoolClient): Promise<
+    QueryResult<{
+      signature_type: Tables.CompiledContractsSignatures["signature_type"];
+      count: string;
+    }>
+  > {
     return await (poolClient || this.pool).query(
-      `SELECT COUNT(DISTINCT s.signature_hash_32) as count
-        FROM signatures s
-        JOIN compiled_contracts_signatures ccs ON s.signature_hash_32 = ccs.signature_hash_32
-        WHERE ccs.signature_type = $1`,
-      [signatureType],
+      `SELECT signature_type, COUNT(DISTINCT signature_hash_32) AS count
+      FROM ${this.schema}.compiled_contracts_signatures
+      GROUP BY signature_type;`,
     );
   }
 

--- a/services/server/src/server/signature-api/openchain.handlers.ts
+++ b/services/server/src/server/signature-api/openchain.handlers.ts
@@ -223,20 +223,11 @@ export async function getSignaturesStats(
       count: { function: 0, event: 0, error: 0 },
     };
 
-    const getSignatureCount = async (type: SignatureType) => {
-      const dbResult =
-        await databaseService.database.getSignatureCountByType(type);
+    const dbResult = await databaseService.database.getSignatureCounts();
 
-      if (dbResult.rows.length === 0) {
-        throw new Error(`No rows returned from count query for type ${type}`);
-      }
-
-      result.count[type] = parseInt(dbResult.rows[0].count, 10);
-    };
-
-    await Promise.all(
-      Object.values(SignatureType).map((type) => getSignatureCount(type)),
-    );
+    for (const row of dbResult.rows) {
+      result.count[row.signature_type] = parseInt(row.count);
+    }
 
     res.status(StatusCodes.OK).json({
       ok: true,


### PR DESCRIPTION
## Summary
- replace the `/stats` endpoint’s three per-type COUNT queries with one grouped query (`SELECT signature_type, COUNT(DISTINCT signature_hash_32)… GROUP BY signature_type`)
- drop the join to `signatures` and read directly from `compiled_contracts_signatures`, so we scan the table once and let Postgres return one row per signature type
- update `getSignaturesStats` to consume the grouped results while preserving zero defaults for any missing type
