### PR TITLE
Order signatures in `?fields=signatures` API response

### DIFF
--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -334,7 +334,7 @@ function generateSignaturesSelector(type: SignatureType) {
           'signature', signatures.signature,
           'signatureHash32', concat('0x', encode(signatures.signature_hash_32, 'hex')),
           'signatureHash4', concat('0x', encode(signatures.signature_hash_4, 'hex'))
-        )
+        ) ORDER BY signatures.signature
       ) FILTER (WHERE compiled_contracts_signatures.signature_type = '${type}'),
       '[]'::json
     ) as ${type}_signatures


### PR DESCRIPTION
We have a flaky test test here:
https://app.circleci.com/pipelines/github/argotorg/sourcify/9529/workflows/31c8bd4c-3f4b-4456-9d1d-33dc015358aa/jobs/55675

The issue is that we check the response for deep equality and the signature result array depends on the postgres storage layout. This PR makes the signature selector to order the result array by the text form signature. The signatures in the test are already order alphabetically.