### PR TITLE
Optimize signature search and materialized view for /stats

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -262,7 +262,7 @@ jobs:
   tests-node-v22:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -262,7 +262,7 @@ jobs:
   tests-node-v22:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -26,7 +26,7 @@ jobs:
   node-v22:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify
@@ -69,7 +69,7 @@ jobs:
   test-new-chain:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify
@@ -102,7 +102,7 @@ jobs:
   validate-database-schema:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres

--- a/.circleci/new_branch.yml
+++ b/.circleci/new_branch.yml
@@ -26,7 +26,7 @@ jobs:
   node-v22:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify
@@ -69,7 +69,7 @@ jobs:
   test-new-chain:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify
@@ -102,7 +102,7 @@ jobs:
   validate-database-schema:
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_PASSWORD: password
           POSTGRES_USER: postgres

--- a/.circleci/nightly.yml
+++ b/.circleci/nightly.yml
@@ -126,7 +126,7 @@ jobs:
             SOURCIFY_POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/.circleci/nightly.yml
+++ b/.circleci/nightly.yml
@@ -126,7 +126,7 @@ jobs:
             SOURCIFY_POSTGRES_PORT: 5432
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/.circleci/test-chains-regularly.yml
+++ b/.circleci/test-chains-regularly.yml
@@ -33,7 +33,7 @@ jobs:
           path: ./services/server/chain-tests-report
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:15.13-alpine
+      - image: postgres:15-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/.circleci/test-chains-regularly.yml
+++ b/.circleci/test-chains-regularly.yml
@@ -33,7 +33,7 @@ jobs:
           path: ./services/server/chain-tests-report
     docker:
       - image: cimg/node:22.5.1
-      - image: postgres:16-alpine
+      - image: postgres:15.13-alpine
         environment:
           POSTGRES_DB: sourcify
           POSTGRES_USER: sourcify

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -9,6 +9,8 @@ A complete dump of the Sourcify database schema can be found in `./sourcify-data
 
 ## Running the database
 
+We use PostgreSQL 15.13 for the database. Higher versions should also work but are not tested.
+
 ### Run with Docker
 
 For convenience, you can run the Postgres container in `docker-compose.yml` with

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -81,7 +81,7 @@ Please follow these steps:
 
 1. Create a new migration file: `npm run migrate:new <migration_name>`
 2. Add the required SQL for the schema change to the generated migration file (e.g., `./migrations/20250717103432_<migration_name>.sql`).
-3. Apply the new migration to a local database: `npm run migrate:up`. `dbmate` automatically generates the updated `sourcify-database.sql` dump. The there will be an error because the dump is not yet generated. This step will be skipped. You can run `dbmate dump` to generate the dump manually or see the errors.
+3. Apply the new migration to a local database: `npm run migrate:up`. `dbmate` automatically generates the updated `sourcify-database.sql` dump. There won't be an error if the dump cannot be generated. You can run `dbmate dump` to generate the dump manually or see the errors.
 4. Commit both the new migration file and the updated `sourcify-database.sql` to the repository.
 
 Important: Since the schema dump should be committed, ensure that the connected database does not contain any custom schema changes that are not part of the migrations.

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -37,6 +37,8 @@ Please initialize the Verifier Alliance [database-specs](https://github.com/veri
 git submodule update --init
 ```
 
+**Extension**: pg_cron is used to schedule the refresh of the signature stats materialized view.
+
 dbmate is used to manage the database migrations.
 A local installation of dbmate comes with `npm i`.
 We will use npm scripts here for running dbmate in order to automatically include the Verifier Alliance migrations when necessary.

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -77,7 +77,7 @@ Please follow these steps:
 
 1. Create a new migration file: `npm run migrate:new <migration_name>`
 2. Add the required SQL for the schema change to the generated migration file (e.g., `./migrations/20250717103432_<migration_name>.sql`).
-3. Apply the new migration to a local database to generate the updated `sourcify-database.sql` dump: `npm run migrate:up`
+3. Apply the new migration to a local database: `npm run migrate:up`. `dbmate` automatically generates the updated `sourcify-database.sql` dump. The there will be an error because the dump is not yet generated. This step will be skipped. You can run `dbmate dump` to generate the dump manually or see the errors.
 4. Commit both the new migration file and the updated `sourcify-database.sql` to the repository.
 
 Important: Since the schema dump should be committed, ensure that the connected database does not contain any custom schema changes that are not part of the migrations.

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -37,7 +37,7 @@ Please initialize the Verifier Alliance [database-specs](https://github.com/veri
 git submodule update --init
 ```
 
-**Extension**: pg_cron is used to schedule the refresh of the signature stats materialized view.
+**Extension**: pg_cron is used to schedule the refresh of the signature stats materialized view. If the pg_cron extension is not available, the migration will be skipped.
 
 dbmate is used to manage the database migrations.
 A local installation of dbmate comes with `npm i`.

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -39,7 +39,7 @@ Please initialize the Verifier Alliance [database-specs](https://github.com/veri
 git submodule update --init
 ```
 
-**Extension**: pg_cron is used to schedule the refresh of the signature stats materialized view. If the pg_cron extension is not available, the migration will be skipped.
+**Extension**: `pg_cron` is used to schedule the refresh of the signature stats materialized view. If the `pg_cron` extension is not available, adding `pg_cron` and creating the cron job will be skipped in the migration.
 
 dbmate is used to manage the database migrations.
 A local installation of dbmate comes with `npm i`.

--- a/services/database/docker-compose.yml
+++ b/services/database/docker-compose.yml
@@ -2,7 +2,14 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:15.13-alpine
+    build:
+      context: .
+      dockerfile_inline: |
+        FROM postgres:15.13-bookworm
+        RUN apt-get update && \
+            apt-get -y install postgresql-15-cron && \
+            apt-get clean && \
+            rm -rf /var/lib/apt/lists/*
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:
@@ -11,6 +18,14 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     ports:
       - ${DOCKER_HOST_POSTGRES_PORT}:${POSTGRES_PORT}
+    command:
+      [
+        "postgres",
+        "-c",
+        "shared_preload_libraries=pg_cron",
+        "-c",
+        "cron.database_name=${POSTGRES_DB}",
+      ]
 
 volumes:
   postgres_data:

--- a/services/database/docker-compose.yml
+++ b/services/database/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM postgres:15.13-bookworm
+        FROM postgres:15-bookworm
         RUN apt-get update && \
             apt-get -y install postgresql-15-cron && \
             apt-get clean && \

--- a/services/database/docker-compose.yml
+++ b/services/database/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:15.13-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data
     environment:

--- a/services/database/migrations/20250922140427_optimize_signature_search.sql
+++ b/services/database/migrations/20250922140427_optimize_signature_search.sql
@@ -1,0 +1,15 @@
+-- migrate:up
+
+-- Enable pg_trgm extension for trigram text search
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- Add trigram GIN index for fast LIKE pattern matching on signature column
+-- This handles both exact matches and wildcard searches efficiently
+-- Note: Using LIKE (case-sensitive) not ILIKE
+CREATE INDEX signatures_signature_trgm_idx
+ON signatures USING GIN (signature gin_trgm_ops);
+
+-- migrate:down
+
+-- Remove the indexes
+DROP INDEX IF EXISTS signatures_signature_trgm_idx;

--- a/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
+++ b/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
@@ -1,0 +1,39 @@
+-- migrate:up
+
+-- Enable pg_cron extension for scheduled tasks
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Create materialized view for signature statistics
+-- This pre-computes the counts that the /stats endpoint needs
+CREATE MATERIALIZED VIEW signature_stats AS
+SELECT
+  signature_type,
+  COUNT(DISTINCT signature_hash_32) AS count
+FROM compiled_contracts_signatures
+GROUP BY signature_type;
+
+-- Add index for fast lookups
+CREATE UNIQUE INDEX signature_stats_type_idx ON signature_stats (signature_type);
+
+-- Create function to refresh the materialized view
+CREATE OR REPLACE FUNCTION refresh_signature_stats()
+RETURNS void AS $$
+BEGIN
+  REFRESH MATERIALIZED VIEW signature_stats;
+  -- Log the refresh for monitoring
+  RAISE NOTICE 'Signature stats materialized view refreshed at %', now();
+END;
+$$ LANGUAGE plpgsql;
+
+-- Schedule daily refresh at 2 AM UTC
+-- This keeps stats current without impacting real-time performance
+SELECT cron.schedule('refresh-signature-stats', '0 2 * * *', 'SELECT refresh_signature_stats();');
+
+-- migrate:down
+
+-- Remove scheduled job
+SELECT cron.unschedule('refresh-signature-stats');
+
+-- Drop function and materialized view
+DROP FUNCTION IF EXISTS refresh_signature_stats();
+DROP MATERIALIZED VIEW IF EXISTS signature_stats;

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,8 +1,3 @@
-\restrict TnBpHlrqaAKIKzkVi8UXta6dKKilKvtqbOUl1OV1fco96HyAydsxcgxnhLcaLzA
-
--- Dumped from database version 16.10 (Ubuntu 16.10-0ubuntu0.24.04.1)
--- Dumped by pg_dump version 16.10 (Ubuntu 16.10-0ubuntu0.24.04.1)
-
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
@@ -13,6 +8,20 @@ SET check_function_bodies = false;
 SET xmloption = content;
 SET client_min_messages = warning;
 SET row_security = off;
+
+--
+-- Name: pg_trgm; Type: EXTENSION; Schema: -; Owner: -
+--
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA public;
+
+
+--
+-- Name: EXTENSION pg_trgm; Type: COMMENT; Schema: -; Owner: -
+--
+
+COMMENT ON EXTENSION pg_trgm IS 'text similarity measurement and index searching based on trigrams';
+
 
 --
 -- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
@@ -1503,6 +1512,13 @@ CREATE INDEX signatures_hash_4_idx ON public.signatures USING btree (signature_h
 
 
 --
+-- Name: signatures_signature_trgm_idx; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX signatures_signature_trgm_idx ON public.signatures USING gin (signature public.gin_trgm_ops);
+
+
+--
 -- Name: sourcify_matches_verified_contract_id_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -1989,8 +2005,6 @@ ALTER TABLE ONLY public.verified_contracts
 -- PostgreSQL database dump complete
 --
 
-\unrestrict TnBpHlrqaAKIKzkVi8UXta6dKKilKvtqbOUl1OV1fco96HyAydsxcgxnhLcaLzA
-
 
 --
 -- Dbmate schema migrations
@@ -2000,4 +2014,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20250717103432'),
     ('20250722133557'),
     ('20250723145429'),
-    ('20250828092603');
+    ('20250828092603'),
+    ('20250922140427');

--- a/services/server/docker-compose.local.yml
+++ b/services/server/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:15.13-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/docker-compose.local.yml
+++ b/services/server/docker-compose.local.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:15.13-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/docker-compose.yml
+++ b/services/server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:15.13-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/docker-compose.yml
+++ b/services/server/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db:
-    image: postgres:16-alpine
+    image: postgres:15.13-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -788,13 +788,13 @@ ${
   async getSignatureCounts(poolClient?: PoolClient): Promise<
     QueryResult<{
       signature_type: Tables.CompiledContractsSignatures["signature_type"];
-      count: string;
+      count: number;
     }>
   > {
     return await (poolClient || this.pool).query(
-      `SELECT signature_type, COUNT(DISTINCT signature_hash_32) AS count
-      FROM ${this.schema}.compiled_contracts_signatures
-      GROUP BY signature_type;`,
+      `SELECT signature_type, count
+      FROM ${this.schema}.signature_stats
+      ORDER BY signature_type;`,
     );
   }
 

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -812,17 +812,18 @@ ${
     }>
   > {
     const sanitizedPattern = pattern
+      .trim()
       .replace(/_/g, "\\_")
       .replace(/\*/g, "%")
       .replace(/\?/g, "_");
 
     return await (poolClient || this.pool).query(
-      `SELECT DISTINCT s.signature, 
+      `SELECT DISTINCT s.signature,
         concat('0x',encode(s.signature_hash_4, 'hex')) as signature_hash_4,
         concat('0x',encode(s.signature_hash_32, 'hex')) as signature_hash_32
         FROM ${this.schema}.signatures s
         JOIN ${this.schema}.compiled_contracts_signatures ccs ON s.signature_hash_32 = ccs.signature_hash_32
-        WHERE s.signature ILIKE $1 AND ccs.signature_type = $2
+        WHERE s.signature LIKE $1 ESCAPE '\\' AND ccs.signature_type = $2
         LIMIT $3`,
       [sanitizedPattern, signatureType, limit],
     );

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -788,7 +788,7 @@ ${
   async getSignatureCounts(poolClient?: PoolClient): Promise<
     QueryResult<{
       signature_type: Tables.CompiledContractsSignatures["signature_type"];
-      count: number;
+      count: string;
       created_at: Date;
       refreshed_at: Date;
     }>

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -789,10 +789,12 @@ ${
     QueryResult<{
       signature_type: Tables.CompiledContractsSignatures["signature_type"];
       count: number;
+      created_at: Date;
+      refreshed_at: Date;
     }>
   > {
     return await (poolClient || this.pool).query(
-      `SELECT signature_type, count
+      `SELECT signature_type, count, created_at, refreshed_at
       FROM ${this.schema}.signature_stats
       ORDER BY signature_type;`,
     );

--- a/services/server/src/server/signature-api/openchain.handlers.ts
+++ b/services/server/src/server/signature-api/openchain.handlers.ts
@@ -230,7 +230,7 @@ export async function getSignaturesStats(
     const dbResult = await databaseService.database.getSignatureCounts();
 
     for (const row of dbResult.rows) {
-      result.count[row.signature_type] = parseInt(row.count);
+      result.count[row.signature_type] = row.count;
     }
 
     res.status(StatusCodes.OK).json({

--- a/services/server/src/server/signature-api/openchain.handlers.ts
+++ b/services/server/src/server/signature-api/openchain.handlers.ts
@@ -238,7 +238,7 @@ export async function getSignaturesStats(
     const dbResult = await databaseService.database.getSignatureCounts();
 
     for (const row of dbResult.rows) {
-      result.count[row.signature_type] = row.count;
+      result.count[row.signature_type] = parseInt(row.count);
 
       // Set metadata from the first row (all rows have same timestamps)
       if (result.metadata.created_at === "") {

--- a/services/server/src/server/signature-api/openchain.handlers.ts
+++ b/services/server/src/server/signature-api/openchain.handlers.ts
@@ -209,6 +209,10 @@ interface GetSignatureStatsResult {
     event: number;
     error: number;
   };
+  metadata: {
+    created_at: string;
+    refreshed_at: string;
+  };
 }
 
 type GetSignaturesStatsResponse = SignatureApiResponse<GetSignatureStatsResult>;
@@ -225,12 +229,22 @@ export async function getSignaturesStats(
 
     const result: GetSignatureStatsResult = {
       count: { function: 0, event: 0, error: 0 },
+      metadata: {
+        created_at: "",
+        refreshed_at: "",
+      },
     };
 
     const dbResult = await databaseService.database.getSignatureCounts();
 
     for (const row of dbResult.rows) {
       result.count[row.signature_type] = row.count;
+
+      // Set metadata from the first row (all rows have same timestamps)
+      if (result.metadata.created_at === "") {
+        result.metadata.created_at = row.created_at.toISOString();
+        result.metadata.refreshed_at = row.refreshed_at.toISOString();
+      }
     }
 
     res.status(StatusCodes.OK).json({

--- a/services/server/src/signature-database.yaml
+++ b/services/server/src/signature-database.yaml
@@ -77,14 +77,14 @@ paths:
   /signature-database/v1/search:
     get:
       summary: Search signatures
-      description: Search signatures by name (case insensitive) with wildcards, limited to the first 100 unordered results
+      description: Search signatures by name (case sensitive) with wildcards, limited to the first 100 unordered results
       tags:
         - Signature Database
       parameters:
         - in: query
           name: query
           required: true
-          description: The name of the function to search for. Case insensitive. Use '*' and '?' for wildcards.
+          description: The name of the function to search for. Case sensitive. Use '*' and '?' for wildcards.
           schema:
             type: string
           allowReserved: true

--- a/services/server/test/docker-compose.yml
+++ b/services/server/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db-test:
-    image: postgres:15.13-alpine
+    image: postgres:15-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/test/docker-compose.yml
+++ b/services/server/test/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   db-test:
-    image: postgres:16-alpine
+    image: postgres:15.13-alpine
     environment:
       POSTGRES_DB: "sourcify"
       POSTGRES_USER: "sourcify"

--- a/services/server/test/integration/signature-api/openchain.spec.ts
+++ b/services/server/test/integration/signature-api/openchain.spec.ts
@@ -43,6 +43,13 @@ describe("Signature API OpenChain Endpoints", function () {
       signature_type: "function" as const,
     },
     {
+      signature: "test_underscore()",
+      signature_hash_32: bytesFromString(
+        keccak256("test_underscore()"),
+      ) as BytesKeccak,
+      signature_type: "function" as const,
+    },
+    {
       signature: "Transfer(address,address,uint256)",
       signature_hash_32: bytesFromString(
         keccak256("Transfer(address,address,uint256)"),
@@ -137,7 +144,11 @@ describe("Signature API OpenChain Endpoints", function () {
     });
 
     it("should lookup event signatures by 32-byte hash", async function () {
-      const hash32 = "0x" + testSignatures[4].signature_hash_32.toString("hex");
+      const hash32 =
+        "0x" +
+        testSignatures
+          .find((sig) => sig.signature_type === "event")
+          ?.signature_hash_32.toString("hex");
 
       const res = await chai
         .request(serverFixture.server.app)
@@ -156,7 +167,10 @@ describe("Signature API OpenChain Endpoints", function () {
     it("should lookup error signatures by hash", async function () {
       const hash4 =
         "0x" +
-        testSignatures[6].signature_hash_32.toString("hex").substring(0, 8);
+        testSignatures
+          .find((sig) => sig.signature_type === "error")
+          ?.signature_hash_32.toString("hex")
+          .substring(0, 8);
 
       const res = await chai
         .request(serverFixture.server.app)
@@ -304,7 +318,7 @@ describe("Signature API OpenChain Endpoints", function () {
       ).flat() as any[];
 
       const transferResults = functionResults.filter((sig: any) =>
-        sig.name.toLowerCase().startsWith("transfer"),
+        sig.name.startsWith("transfer"),
       );
       chai.expect(transferResults.length).to.be.at.least(2);
 
@@ -319,7 +333,7 @@ describe("Signature API OpenChain Endpoints", function () {
       chai.expect(hasTransferFrom).to.be.true;
     });
 
-    it("should search with case insensitive pattern", async function () {
+    it("should search with case sensitive pattern", async function () {
       const res = await chai
         .request(serverFixture.server.app)
         .get("/signature-database/v1/search")
@@ -332,9 +346,9 @@ describe("Signature API OpenChain Endpoints", function () {
         res.body.result.function,
       ).flat() as any[];
       const hasTransferFunction = functionResults.some((sig: any) =>
-        sig.name.toLowerCase().includes("transfer"),
+        sig.name.includes("transfer"),
       );
-      chai.expect(hasTransferFunction).to.be.true;
+      chai.expect(hasTransferFunction).to.be.false;
     });
 
     it("should support wildcard search with ?", async function () {
@@ -350,9 +364,27 @@ describe("Signature API OpenChain Endpoints", function () {
         res.body.result.function,
       ).flat() as any[];
       const hasApproveFunction = functionResults.some((sig: any) =>
-        sig.name.toLowerCase().includes("approve"),
+        sig.name.includes("approve"),
       );
       chai.expect(hasApproveFunction).to.be.true;
+    });
+
+    it("should escape underscore in search", async function () {
+      const res = await chai
+        .request(serverFixture.server.app)
+        .get("/signature-database/v1/search")
+        .query({ query: "test_underscore()" });
+
+      chai.expect(res.status).to.equal(200);
+      chai.expect(res.body.ok).to.be.true;
+
+      const functionResults = Object.values(
+        res.body.result.function,
+      ).flat() as any[];
+      const hasTestUnderscoreFunction = functionResults.some((sig: any) =>
+        sig.name.includes("test_underscore"),
+      );
+      chai.expect(hasTestUnderscoreFunction).to.be.true;
     });
 
     it("should handle missing query parameter in search", async function () {

--- a/services/server/test/integration/signature-api/openchain.spec.ts
+++ b/services/server/test/integration/signature-api/openchain.spec.ts
@@ -398,6 +398,13 @@ describe("Signature API OpenChain Endpoints", function () {
 
   describe("GET /signature-database/v1/stats", function () {
     it("should return signature statistics", async function () {
+      // Manually refresh the materialized view to ensure fresh stats for this test.
+      await (
+        serverFixture.server.services.storage.rwServices[
+          RWStorageIdentifiers.SourcifyDatabase
+        ] as SourcifyDatabaseService
+      ).database.pool.query("REFRESH MATERIALIZED VIEW signature_stats");
+
       const res = await chai
         .request(serverFixture.server.app)
         .get("/signature-database/v1/stats");


### PR DESCRIPTION
- Adds GIN index to `signatures.signature` for fast `LIKE` search
- Enables `pg_trgm` for efficient trigram search
- Handles `_` escape
- Adds and underscore function name test and updates other tests to be independent of the order of inserted functions.
- Creates a materialized view `sourcify_stats` for the `/stats` endpoint to use. Adds when this materialized view was last updated and adds that field to the /stats response.
- Adds `pg_cron` to update the stats daily

TODO:
- [x] Need to enable `pg_cron` on GCP postgres instances
- [x] Apply the migrations on live DBs