### PR TITLE
Remove buggy the refresh_materialized_view function, raise the pg notice to log level

### DIFF
--- a/services/database/README.md
+++ b/services/database/README.md
@@ -41,7 +41,7 @@ git submodule update --init
 
 **Extensions**
 
-- `pg_cron`: used to schedule the refresh of the signature stats materialized view. Make sure you [install the `pg_cron` extension](https://github.com/citusdata/pg_cron) abd set the `cron.database_name` variable to the name of the database you are using.
+- `pg_cron`: used to schedule the refresh of the signature stats materialized view. Make sure you [install the `pg_cron` extension](https://github.com/citusdata/pg_cron) and set the `cron.database_name` variable to the name of the database you are using.
   - If the `pg_cron` extension is not available, adding `pg_cron` and creating the cron job will be skipped in the migration.
   - In Google Cloud SQL, you can install the extension by setting the flag `cloudsql.enable_pg_cron` to `true`, and setting the `cron.database_name` flag to the name of the database you are using.
 - `pg_trgm`: used to create the index on the `signatures` table.

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -39,7 +39,13 @@ Please initialize the Verifier Alliance [database-specs](https://github.com/veri
 git submodule update --init
 ```
 
-**Extension**: `pg_cron` is used to schedule the refresh of the signature stats materialized view. If the `pg_cron` extension is not available, adding `pg_cron` and creating the cron job will be skipped in the migration.
+**Extensions**
+
+- `pg_cron`: used to schedule the refresh of the signature stats materialized view. Make sure you [install the `pg_cron` extension](https://github.com/citusdata/pg_cron) abd set the `cron.database_name` variable to the name of the database you are using.
+  - If the `pg_cron` extension is not available, adding `pg_cron` and creating the cron job will be skipped in the migration.
+  - In Google Cloud SQL, you can install the extension by setting the flag `cloudsql.enable_pg_cron` to `true`, and setting the `cron.database_name` flag to the name of the database you are using.
+- `pg_trgm`: used to create the index on the `signatures` table.
+- `pgcrypto`: used to create the `signature_type_enum` type.
 
 dbmate is used to manage the database migrations.
 A local installation of dbmate comes with `npm i`.

--- a/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
+++ b/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
@@ -4,9 +4,9 @@
 DO $$
 BEGIN
     CREATE EXTENSION IF NOT EXISTS pg_cron;
-    RAISE NOTICE 'pg_cron extension enabled successfully';
+    RAISE LOG 'pg_cron extension enabled successfully';
 EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'pg_cron extension not available, continuing without scheduled refresh';
+    RAISE LOG 'pg_cron extension not available, continuing without scheduled refresh. Error: %', SQLERRM;
 END
 $$;
 
@@ -24,29 +24,14 @@ GROUP BY signature_type;
 -- Add index for fast lookups
 CREATE UNIQUE INDEX signature_stats_type_idx ON signature_stats (signature_type);
 
--- Create function to refresh the materialized view
-CREATE OR REPLACE FUNCTION refresh_signature_stats()
-RETURNS void AS $$
-BEGIN
-  -- Refresh materialized view with updated timestamps
-  REFRESH MATERIALIZED VIEW signature_stats;
-
-  -- Update refreshed_at timestamp for all rows
-  UPDATE signature_stats SET refreshed_at = now();
-
-  -- Log the refresh for monitoring
-  RAISE NOTICE 'Signature stats materialized view refreshed at %', now();
-END;
-$$ LANGUAGE plpgsql;
-
 -- Schedule daily refresh at 2 AM UTC (only if pg_cron is available)
 -- This keeps stats current without impacting real-time performance
 DO $$
 BEGIN
-    PERFORM cron.schedule('refresh-signature-stats', '0 2 * * *', 'SELECT refresh_signature_stats();');
-    RAISE NOTICE 'Scheduled daily refresh of signature stats at 2 AM UTC';
+    PERFORM cron.schedule('refresh-signature-stats', '0 2 * * *', 'REFRESH MATERIALIZED VIEW signature_stats;');
+    RAISE LOG 'Scheduled daily refresh of signature stats at 2 AM UTC';
 EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'pg_cron not available, materialized view refresh must be done manually';
+    RAISE LOG 'pg_cron not available, materialized view refresh must be done manually. Error: %', SQLERRM;
 END
 $$;
 
@@ -56,12 +41,11 @@ $$;
 DO $$
 BEGIN
     PERFORM cron.unschedule('refresh-signature-stats');
-    RAISE NOTICE 'Unscheduled signature stats refresh job';
+    RAISE LOG 'Unscheduled signature stats refresh job';
 EXCEPTION WHEN OTHERS THEN
-    RAISE NOTICE 'pg_cron not available or job not found, continuing with cleanup';
+    RAISE LOG 'pg_cron not available or job not found, continuing with cleanup. Error: %', SQLERRM;
 END
 $$;
 
--- Drop function and materialized view
-DROP FUNCTION IF EXISTS refresh_signature_stats();
+-- Drop materialized view
 DROP MATERIALIZED VIEW IF EXISTS signature_stats;

--- a/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
+++ b/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
@@ -16,7 +16,6 @@ CREATE MATERIALIZED VIEW signature_stats AS
 SELECT
   signature_type,
   COUNT(DISTINCT signature_hash_32) AS count,
-  now() AS created_at,
   now() AS refreshed_at
 FROM compiled_contracts_signatures
 GROUP BY signature_type;

--- a/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
+++ b/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
@@ -4,9 +4,9 @@
 DO $$
 BEGIN
     CREATE EXTENSION IF NOT EXISTS pg_cron;
-    RAISE LOG 'pg_cron extension enabled successfully';
+    RAISE WARNING 'pg_cron extension enabled successfully';
 EXCEPTION WHEN OTHERS THEN
-    RAISE LOG 'pg_cron extension not available, continuing without scheduled refresh. Error: %', SQLERRM;
+    RAISE WARNING 'pg_cron extension not available, continuing without scheduled refresh. Error: %', SQLERRM;
 END
 $$;
 
@@ -28,9 +28,9 @@ CREATE UNIQUE INDEX signature_stats_type_idx ON signature_stats (signature_type)
 DO $$
 BEGIN
     PERFORM cron.schedule('refresh-signature-stats', '0 2 * * *', 'REFRESH MATERIALIZED VIEW signature_stats;');
-    RAISE LOG 'Scheduled daily refresh of signature stats at 2 AM UTC';
+    RAISE WARNING 'Scheduled daily refresh of signature stats at 2 AM UTC';
 EXCEPTION WHEN OTHERS THEN
-    RAISE LOG 'pg_cron not available, materialized view refresh must be done manually. Error: %', SQLERRM;
+    RAISE WARNING 'pg_cron not available, materialized view refresh must be done manually. Error: %', SQLERRM;
 END
 $$;
 
@@ -40,9 +40,9 @@ $$;
 DO $$
 BEGIN
     PERFORM cron.unschedule('refresh-signature-stats');
-    RAISE LOG 'Unscheduled signature stats refresh job';
+    RAISE WARNING 'Unscheduled signature stats refresh job';
 EXCEPTION WHEN OTHERS THEN
-    RAISE LOG 'pg_cron not available or job not found, continuing with cleanup. Error: %', SQLERRM;
+    RAISE WARNING 'pg_cron not available or job not found, continuing with cleanup. Error: %', SQLERRM;
 END
 $$;
 

--- a/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
+++ b/services/database/migrations/20250922141802_signature_stats_materialized_view.sql
@@ -1,6 +1,7 @@
 -- migrate:up
 
 -- Enable pg_cron extension for scheduled tasks (gracefully handle if not available)
+-- By default this only runs on the database "postgres" but you can set the cron.database_name variable in the postgresql.conf to a different database.
 DO $$
 BEGIN
     CREATE EXTENSION IF NOT EXISTS pg_cron;

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -146,26 +146,6 @@ $$;
 
 
 --
--- Name: refresh_signature_stats(); Type: FUNCTION; Schema: public; Owner: -
---
-
-CREATE FUNCTION public.refresh_signature_stats() RETURNS void
-    LANGUAGE plpgsql
-    AS $$
-BEGIN
-  -- Refresh materialized view with updated timestamps
-  REFRESH MATERIALIZED VIEW signature_stats;
-
-  -- Update refreshed_at timestamp for all rows
-  UPDATE signature_stats SET refreshed_at = now();
-
-  -- Log the refresh for monitoring
-  RAISE NOTICE 'Signature stats materialized view refreshed at %', now();
-END;
-$$;
-
-
---
 -- Name: trigger_reuse_created_at(); Type: FUNCTION; Schema: public; Owner: -
 --
 
@@ -1045,7 +1025,6 @@ CREATE TABLE public.session (
 CREATE MATERIALIZED VIEW public.signature_stats AS
  SELECT compiled_contracts_signatures.signature_type,
     count(DISTINCT compiled_contracts_signatures.signature_hash_32) AS count,
-    now() AS created_at,
     now() AS refreshed_at
    FROM public.compiled_contracts_signatures
   GROUP BY compiled_contracts_signatures.signature_type

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -791,12 +791,11 @@ ${
     QueryResult<{
       signature_type: Tables.CompiledContractsSignatures["signature_type"];
       count: string;
-      created_at: Date;
       refreshed_at: Date;
     }>
   > {
     return await (poolClient || this.pool).query(
-      `SELECT signature_type, count, created_at, refreshed_at
+      `SELECT signature_type, count, refreshed_at
       FROM ${this.schema}.signature_stats
       ORDER BY signature_type;`,
     );

--- a/services/server/src/server/signature-api/openchain.handlers.ts
+++ b/services/server/src/server/signature-api/openchain.handlers.ts
@@ -210,7 +210,6 @@ interface GetSignatureStatsResult {
     error: number;
   };
   metadata: {
-    created_at: string;
     refreshed_at: string;
   };
 }
@@ -230,7 +229,6 @@ export async function getSignaturesStats(
     const result: GetSignatureStatsResult = {
       count: { function: 0, event: 0, error: 0 },
       metadata: {
-        created_at: "",
         refreshed_at: "",
       },
     };
@@ -241,8 +239,7 @@ export async function getSignaturesStats(
       result.count[row.signature_type] = parseInt(row.count);
 
       // Set metadata from the first row (all rows have same timestamps)
-      if (result.metadata.created_at === "") {
-        result.metadata.created_at = row.created_at.toISOString();
+      if (result.metadata.refreshed_at === "") {
         result.metadata.refreshed_at = row.refreshed_at.toISOString();
       }
     }

--- a/services/server/test/integration/signature-api/openchain.spec.ts
+++ b/services/server/test/integration/signature-api/openchain.spec.ts
@@ -411,10 +411,18 @@ describe("Signature API OpenChain Endpoints", function () {
 
       chai.expect(res.status).to.equal(200);
       chai.expect(res.body.ok).to.be.true;
+      // stats part
       chai.expect(res.body.result).to.have.property("count");
       chai.expect(res.body.result.count).to.have.property("function");
       chai.expect(res.body.result.count).to.have.property("event");
       chai.expect(res.body.result.count).to.have.property("error");
+      // refreshed_at
+      chai.expect(res.body.result).to.have.property("metadata");
+      chai.expect(res.body.result.metadata).to.have.property("refreshed_at");
+      // should be a valid ISO string
+      chai
+        .expect(new Date(res.body.result.metadata.refreshed_at).toISOString())
+        .to.be.a("string");
 
       const functionCount = testSignatures.filter(
         (sig) => sig.signature_type === "function",


### PR DESCRIPTION
Turns out the original function we wrote was buggy as you can't really UPDATE a materialized view. That's why the refresh failed last night. We can completely get rid of the function and just schedule a direct refresh of the materialized view, and it will take care of the `refreshed_at` columns itself

TODO:
- [x] Execute fix queries on staging
- [ ] Execute fix queries on prod