### PR TITLE
Remove old Celo testnets

### DIFF
--- a/services/monitor/monitorChains.json
+++ b/services/monitor/monitorChains.json
@@ -201,18 +201,6 @@
     ]
   },
   {
-    "name": "Celo Alfajores Testnet",
-    "chainId": 44787,
-    "rpc": [
-      {
-        "type": "ApiKey",
-        "url": "https://celo-alfajores.g.alchemy.com/v2/{API_KEY}",
-        "apiKeyEnvName": "ALCHEMY_API_KEY"
-      },
-      "https://alfajores-forno.celo-testnet.org"
-    ]
-  },
-  {
     "name": "Celo Sepolia Testnet",
     "chainId": 11142220,
     "rpc": [
@@ -222,11 +210,6 @@
         "apiKeyEnvName": "ALCHEMY_API_KEY"
       }
     ]
-  },
-  {
-    "name": "Celo Baklava Testnet",
-    "chainId": 62320,
-    "rpc": ["https://baklava-forno.celo-testnet.org"]
   },
   {
     "name": "Linea Mainnet",

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -388,29 +388,6 @@
       }
     ]
   },
-  "44787": {
-    "sourcifyName": "Celo Alfajores Testnet",
-    "supported": true,
-    "etherscanApi": {
-      "supported": true,
-      "apiKeyEnvName": "ETHERSCAN_API_KEY_CELO"
-    },
-    "fetchContractCreationTxUsing": {
-      "etherscanApi": true,
-      "blockscoutScrape": {
-        "url": "https://explorer.celo.org/alfajores/"
-      }
-    }
-  },
-  "62320": {
-    "sourcifyName": "Celo Baklava Testnet",
-    "supported": true,
-    "fetchContractCreationTxUsing": {
-      "blockscoutScrape": {
-        "url": "https://baklava-blockscout.celo-testnet.org/"
-      }
-    }
-  },
   "11142220": {
     "sourcifyName": "Celo Sepolia Testnet",
     "supported": true,

--- a/services/server/src/sourcify-chains-default.json
+++ b/services/server/src/sourcify-chains-default.json
@@ -388,6 +388,14 @@
       }
     ]
   },
+  "44787": {
+    "sourcifyName": "Celo Alfajores Testnet",
+    "supported": false
+  },
+  "62320": {
+    "sourcifyName": "Celo Baklava Testnet",
+    "supported": false
+  },
   "11142220": {
     "sourcifyName": "Celo Sepolia Testnet",
     "supported": true,

--- a/services/server/test/chains/chain-tests.spec.ts
+++ b/services/server/test/chains/chain-tests.spec.ts
@@ -229,13 +229,6 @@ describe("Test Supported Chains", function () {
   );
 
   verifyContract(
-    "0x8F78b9c92a68DdF719849a40702cFBfa4EB60dD0",
-    "44787",
-    "Celo Alfajores Testnet",
-    "shared/",
-  );
-
-  verifyContract(
     "0xd46fd24ea21F04459407Fb0B518451e54d0b07a1",
     "97",
     "Binance Smart Chain Testnet",
@@ -255,20 +248,6 @@ describe("Test Supported Chains", function () {
   //   "Polygon Mumbai Testnet",
   //   "shared/"
   // );
-
-  verifyContract(
-    "0x03943C3ef00d92e130185CeBC0bcc435Def2cC94",
-    "42220",
-    "Celo Mainnet",
-    "42220/",
-  );
-
-  verifyContract(
-    "0xdd5FFA1DF887D5A42931a746BaAd62574501A5Aa",
-    "62320",
-    "Celo Baklava Testnet",
-    "62320/",
-  );
 
   verifyContract(
     "0x0Ec727eD4b65Ca0e2D80A6a9fdA73D4d3bb042A6",

--- a/services/server/test/helpers/etherscanInstanceContracts.json
+++ b/services/server/test/helpers/etherscanInstanceContracts.json
@@ -113,18 +113,6 @@
       "expectedStatus": "perfect"
     }
   ],
-  "44787": [
-    {
-      "address": "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
-      "type": "single",
-      "expectedStatus": "partial"
-    },
-    {
-      "address": "0x1ff8030705dB05DcDEbEA2BF0f8CDAd1966A71C6",
-      "type": "standard-json",
-      "expectedStatus": "perfect"
-    }
-  ],
   "42220": [
     {
       "address": "0x8084936982D089130e001b470eDf58faCA445008",


### PR DESCRIPTION
Since Holesky will be shut down end of September, the L2 testnets that use Holesky as L1 will also stop working. Let's clean up and remove the entries for the Holesky-based Celo networks.