### PR TITLE
fix: handling of empty directories in `process_directory`

### DIFF
--- a/scripts/rename_repov2_sol_extension.sh
+++ b/scripts/rename_repov2_sol_extension.sh
@@ -16,6 +16,7 @@ remove_sol_extension() {
 # Recursive function to process directories
 process_directory() {
     local dir="$1"
+    shopt -s nullglob
     for item in "$dir"/*; do
         if [[ -d "$item" ]]; then
             process_directory "$item"
@@ -23,6 +24,7 @@ process_directory() {
             remove_sol_extension "$item"
         fi
     done
+    shopt -u nullglob
 }
 
 


### PR DESCRIPTION
added `shopt -s nullglob` before the loop and reset it with `shopt -u nullglob` afterwards.
This ensures that empty directories are not expanded as literal `"dir/*"`.

by wrapping the `for item in "$dir"/*` loop in `nullglob`, the script now behaves correctly with empty folders and unusual filenames, this makes the directory processing more robust and safe.

## Checklist

- [ ] The branch is named as `add-chain-<chainId>`.
- [ ] I haven't modified the `chains.json` file directly.
- [ ] In `sourcify-chains.json` file
  - [ ] I've set `supported: true`.
  - [ ] I haven't added an `rpc` field but the one in [chains.json](../../src/chains.json) is used (if not, please explain why).
- [ ] I've added a test in [chain-tests.js](../../test/chains/chains-test.js) file.
- [ ] `test-new-chain` test in Circle CI is passing.
