### PR TITLE
Fix homepage link in package.json

### DIFF
--- a/packages/compilers-types/package.json
+++ b/packages/compilers-types/package.json
@@ -33,7 +33,7 @@
   "bugs": {
     "url": "https://github.com/argotorg/sourcify/issues"
   },
-  "homepage": "https://github.com/argotorg/sourcify/tree/main/packages/compilers-types#readme",
+  "homepage": "https://github.com/argotorg/sourcify/tree/staging/packages/compilers-types",
   "devDependencies": {
     "typescript": "5.9.2"
   },


### PR DESCRIPTION
Description:
Replaced the old link https://github.com/argotorg/sourcify/tree/main/packages/compilers-types#readme


New:  https://github.com/argotorg/sourcify/tree/staging/packages/compilers-types


because the old one was broken