### PR TITLE
fix(compilers): sandbox native solc cwd to stop import path leaks

### DIFF
--- a/packages/compilers/src/lib/common.ts
+++ b/packages/compilers/src/lib/common.ts
@@ -78,11 +78,21 @@ export function createCompilerTimeoutError(timeoutMs: number): Error & {
   return timeoutError;
 }
 
+export type AsyncExecOptions = {
+  /**
+   * Working directory for the compiler subprocess.
+   * Used by native solc to isolate import resolution from the host process cwd
+   * (solc >=0.8.8 may read relative imports from base path ".").
+   */
+  cwd?: string;
+};
+
 export function asyncExec(
   command: string,
   inputStringified: string,
   maxBuffer: number,
   timeoutMs: number = DEFAULT_COMPILE_TIMEOUT_MS,
+  options: AsyncExecOptions = {},
 ): Promise<string> {
   // check if input is valid JSON. The input is untrusted and potentially cause arbitrary execution.
   JSON.parse(inputStringified);
@@ -121,6 +131,7 @@ export function asyncExec(
         maxBuffer,
         timeout: timeoutMs,
         killSignal: 'SIGKILL',
+        cwd: options.cwd,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/compilers/src/lib/common.ts
+++ b/packages/compilers/src/lib/common.ts
@@ -1,4 +1,7 @@
 import { exec } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { logDebug, logError, logSilly } from '../logger';
 import type { OutputError } from '@ethereum-sourcify/compilers-types';
 import {
@@ -78,25 +81,46 @@ export function createCompilerTimeoutError(timeoutMs: number): Error & {
   return timeoutError;
 }
 
-export type AsyncExecOptions = {
-  /**
-   * Working directory for the compiler subprocess.
-   * Used by native solc to isolate import resolution from the host process cwd
-   * (solc >=0.8.8 may read relative imports from base path ".").
-   */
-  cwd?: string;
-};
-
-export function asyncExec(
+export async function asyncExec(
   command: string,
   inputStringified: string,
   maxBuffer: number,
   timeoutMs: number = DEFAULT_COMPILE_TIMEOUT_MS,
-  options: AsyncExecOptions = {},
 ): Promise<string> {
   // check if input is valid JSON. The input is untrusted and potentially cause arbitrary execution.
   JSON.parse(inputStringified);
 
+  // Run every compiler subprocess in an empty temp directory. Native solc
+  // --standard-json (notably >=0.8.8) resolves missing imports against the cwd
+  // (allowed base path "."). A user-controlled `import "./.env"` would
+  // otherwise let the compiler read host files and leak their contents through
+  // the compiler error (formattedMessage). An empty cwd makes those imports
+  // resolve to nothing. Callers must pass an absolute binary path in `command`,
+  // since a relative path would no longer resolve once cwd changes.
+  const sandboxCwd = await fs.promises.mkdtemp(
+    path.join(os.tmpdir(), 'sourcify-compiler-'),
+  );
+
+  try {
+    return await runInSandbox(
+      command,
+      inputStringified,
+      maxBuffer,
+      timeoutMs,
+      sandboxCwd,
+    );
+  } finally {
+    await fs.promises.rm(sandboxCwd, { recursive: true, force: true });
+  }
+}
+
+function runInSandbox(
+  command: string,
+  inputStringified: string,
+  maxBuffer: number,
+  timeoutMs: number,
+  sandboxCwd: string,
+): Promise<string> {
   return new Promise((resolve, reject) => {
     // Guard so the promise settles exactly once. Multiple failure signals can
     // race (exec callback, stdin 'error', a thrown write) and double-settling
@@ -131,7 +155,7 @@ export function asyncExec(
         maxBuffer,
         timeout: timeoutMs,
         killSignal: 'SIGKILL',
-        cwd: options.cwd,
+        cwd: sandboxCwd,
       },
       (error, stdout, stderr) => {
         if (error) {

--- a/packages/compilers/src/lib/common.ts
+++ b/packages/compilers/src/lib/common.ts
@@ -90,13 +90,9 @@ export async function asyncExec(
   // check if input is valid JSON. The input is untrusted and potentially cause arbitrary execution.
   JSON.parse(inputStringified);
 
-  // Run every compiler subprocess in an empty temp directory. Native solc
-  // --standard-json (notably >=0.8.8) resolves missing imports against the cwd
-  // (allowed base path "."). A user-controlled `import "./.env"` would
-  // otherwise let the compiler read host files and leak their contents through
-  // the compiler error (formattedMessage). An empty cwd makes those imports
-  // resolve to nothing. Callers must pass an absolute binary path in `command`,
-  // since a relative path would no longer resolve once cwd changes.
+  // Run in an empty temp cwd so a user-controlled `import "./.env"` cannot make
+  // the compiler read host files (#2920). Callers must pass an absolute binary
+  // path in `command`, since a relative one would break once cwd changes.
   const sandboxCwd = await fs.promises.mkdtemp(
     path.join(os.tmpdir(), 'sourcify-compiler-'),
   );

--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -1,7 +1,6 @@
 // TODO: Handle nodejs only dependencies
 import path from 'path';
 import fs from 'fs';
-import os from 'os';
 import { spawnSync } from 'child_process';
 import semver from 'semver';
 import type { WorkerOptions } from 'worker_threads';
@@ -92,35 +91,26 @@ export async function useSolidityCompiler(
   }
   let startCompilation: number;
   if (solcPath && !forceEmscripten) {
-    // Resolve before changing cwd: a relative solcRepo path would otherwise break.
+    // asyncExec runs the compiler in an empty temp cwd (see its comment).
+    // Resolve to an absolute path so the binary still resolves after cwd change.
     const absoluteSolcPath = path.resolve(solcPath);
     logDebug('Compiling with solc binary', {
       version,
       solcPath: absoluteSolcPath,
     });
     startCompilation = Date.now();
-    // Native solc --standard-json (notably >=0.8.8) resolves missing imports
-    // against cwd (allowed base path "."). Older solc rejects those imports as
-    // outside allowed directories. Run in an empty temp dir so user-controlled
-    // imports cannot open host files and leak contents via formattedMessage.
-    const sandboxCwd = await fs.promises.mkdtemp(
-      path.join(os.tmpdir(), 'sourcify-solc-'),
-    );
     try {
       compiled = await asyncExec(
         `${absoluteSolcPath} --standard-json`,
         inputStringified,
         250 * 1024 * 1024,
         timeoutMs,
-        { cwd: sandboxCwd },
       );
     } catch (error: any) {
       if (error?.code === 'ENOBUFS') {
         throw new Error('Compilation output size too large');
       }
       throw error;
-    } finally {
-      await fs.promises.rm(sandboxCwd, { recursive: true, force: true });
     }
   } else {
     // Spawn a dedicated worker so the solcjs compilers is released when the worker exits.

--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -1,6 +1,7 @@
 // TODO: Handle nodejs only dependencies
 import path from 'path';
 import fs from 'fs';
+import os from 'os';
 import { spawnSync } from 'child_process';
 import semver from 'semver';
 import type { WorkerOptions } from 'worker_threads';
@@ -91,20 +92,35 @@ export async function useSolidityCompiler(
   }
   let startCompilation: number;
   if (solcPath && !forceEmscripten) {
-    logDebug('Compiling with solc binary', { version, solcPath });
+    // Resolve before changing cwd: a relative solcRepo path would otherwise break.
+    const absoluteSolcPath = path.resolve(solcPath);
+    logDebug('Compiling with solc binary', {
+      version,
+      solcPath: absoluteSolcPath,
+    });
     startCompilation = Date.now();
+    // Native solc --standard-json (notably >=0.8.8) resolves missing imports
+    // against cwd (allowed base path "."). Older solc rejects those imports as
+    // outside allowed directories. Run in an empty temp dir so user-controlled
+    // imports cannot open host files and leak contents via formattedMessage.
+    const sandboxCwd = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), 'sourcify-solc-'),
+    );
     try {
       compiled = await asyncExec(
-        `${solcPath} --standard-json`,
+        `${absoluteSolcPath} --standard-json`,
         inputStringified,
         250 * 1024 * 1024,
         timeoutMs,
+        { cwd: sandboxCwd },
       );
     } catch (error: any) {
       if (error?.code === 'ENOBUFS') {
         throw new Error('Compilation output size too large');
       }
       throw error;
+    } finally {
+      await fs.promises.rm(sandboxCwd, { recursive: true, force: true });
     }
   } else {
     // Spawn a dedicated worker so the solcjs compilers is released when the worker exits.

--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -91,8 +91,7 @@ export async function useSolidityCompiler(
   }
   let startCompilation: number;
   if (solcPath && !forceEmscripten) {
-    // asyncExec runs the compiler in an empty temp cwd (see its comment).
-    // Resolve to an absolute path so the binary still resolves after cwd change.
+    // Absolute path: asyncExec runs in a temp cwd (#2920), breaking relative paths.
     const absoluteSolcPath = path.resolve(solcPath);
     logDebug('Compiling with solc binary', {
       version,

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -69,9 +69,12 @@ export async function useVyperCompiler(
   let compiled: string | undefined;
   const inputStringified = stringifyVyperJsonInput(vyperJsonInput);
   const startCompilation = Date.now();
+  // asyncExec runs the compiler in an empty temp cwd (see its comment).
+  // Resolve to an absolute path so the binary still resolves after cwd change.
+  const absoluteVyperPath = path.resolve(vyperPath);
   try {
     compiled = await asyncExec(
-      `${vyperPath} --standard-json`,
+      `${absoluteVyperPath} --standard-json`,
       inputStringified,
       250 * 1024 * 1024,
       timeoutMs,

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -69,8 +69,7 @@ export async function useVyperCompiler(
   let compiled: string | undefined;
   const inputStringified = stringifyVyperJsonInput(vyperJsonInput);
   const startCompilation = Date.now();
-  // asyncExec runs the compiler in an empty temp cwd (see its comment).
-  // Resolve to an absolute path so the binary still resolves after cwd change.
+  // Absolute path: asyncExec runs in a temp cwd (#2920), breaking relative paths.
   const absoluteVyperPath = path.resolve(vyperPath);
   try {
     compiled = await asyncExec(

--- a/packages/compilers/test/common.spec.ts
+++ b/packages/compilers/test/common.spec.ts
@@ -1,4 +1,7 @@
 import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
 import { asyncExec } from '../src/lib/common';
 import {
   COMPILER_OOM_CODE,
@@ -82,5 +85,61 @@ describe('asyncExec robustness (#2880)', () => {
     expect(thrown, 'expected asyncExec to reject').to.be.instanceOf(Error);
     expect(thrown.code).to.not.equal(COMPILER_OOM_CODE);
     expect(thrown.code).to.not.equal(COMPILER_TIMEOUT_CODE);
+  });
+});
+
+describe('asyncExec compiler cwd sandbox (import path leak)', () => {
+  // Native compilers (solc --standard-json >=0.8.8) resolve missing imports
+  // against the process cwd. A user-controlled `import "./.env"` would let the
+  // compiler read a host file and leak its content through the compiler error.
+  // asyncExec runs every subprocess in an empty temp dir to prevent this. These
+  // tests exercise that generically with `sh`, so they hold for every compiler
+  // that goes through asyncExec (solc, vyper), independent of any binary.
+  let secretName: string;
+  let secretPath: string;
+
+  beforeEach(() => {
+    secretName = `.sourcify-cwd-leak-test-${process.pid}`;
+    secretPath = path.join(process.cwd(), secretName);
+    fs.writeFileSync(secretPath, 'LEAK_SECRET_VALUE=super-secret\n', 'utf8');
+  });
+
+  afterEach(() => {
+    fs.rmSync(secretPath, { force: true });
+  });
+
+  it('runs the subprocess in an empty temp dir, not the host cwd', async () => {
+    // `pwd` reports the working directory the subprocess actually ran in. It is
+    // a fresh temp dir, not the host cwd where the secret file lives.
+    const cwd = (await asyncExec('pwd', '{}', MAX_BUFFER)).trim();
+    expect(cwd).to.not.equal(process.cwd());
+    expect(cwd.startsWith(fs.realpathSync(os.tmpdir()))).to.equal(true);
+  });
+
+  it('cannot read a host cwd file through a relative path', async () => {
+    // Reading the secret by the same relative path a leaking import would use
+    // must fail, because the sandbox cwd does not contain it.
+    let thrown: any;
+    try {
+      await asyncExec(`cat "./${secretName}"`, '{}', MAX_BUFFER);
+    } catch (error) {
+      thrown = error;
+    }
+    expect(thrown, 'expected the relative read to fail').to.be.instanceOf(
+      Error,
+    );
+    expect(`${thrown?.message ?? ''}`).to.not.contain('super-secret');
+  });
+
+  it('always cleans up the temp dir it created', async () => {
+    const before = fs
+      .readdirSync(os.tmpdir())
+      .filter((d) => d.startsWith('sourcify-compiler-'));
+    await asyncExec('cat', '{}', MAX_BUFFER);
+    const after = fs
+      .readdirSync(os.tmpdir())
+      .filter((d) => d.startsWith('sourcify-compiler-'));
+    // No new sourcify-compiler-* dir is left behind after a successful run.
+    expect(after.length).to.be.at.most(before.length);
   });
 });

--- a/packages/compilers/test/common.spec.ts
+++ b/packages/compilers/test/common.spec.ts
@@ -89,12 +89,8 @@ describe('asyncExec robustness (#2880)', () => {
 });
 
 describe('asyncExec compiler cwd sandbox (import path leak)', () => {
-  // Native compilers (solc --standard-json >=0.8.8) resolve missing imports
-  // against the process cwd. A user-controlled `import "./.env"` would let the
-  // compiler read a host file and leak its content through the compiler error.
-  // asyncExec runs every subprocess in an empty temp dir to prevent this. These
-  // tests exercise that generically with `sh`, so they hold for every compiler
-  // that goes through asyncExec (solc, vyper), independent of any binary.
+  // asyncExec runs every compiler in an empty temp cwd so imports cannot read
+  // host files (#2920). Exercised generically here, so it holds for solc/vyper.
   let secretName: string;
   let secretPath: string;
 
@@ -109,16 +105,14 @@ describe('asyncExec compiler cwd sandbox (import path leak)', () => {
   });
 
   it('runs the subprocess in an empty temp dir, not the host cwd', async () => {
-    // `pwd` reports the working directory the subprocess actually ran in. It is
-    // a fresh temp dir, not the host cwd where the secret file lives.
+    // `pwd` reports where the subprocess ran: a temp dir, not the host cwd.
     const cwd = (await asyncExec('pwd', '{}', MAX_BUFFER)).trim();
     expect(cwd).to.not.equal(process.cwd());
     expect(cwd.startsWith(fs.realpathSync(os.tmpdir()))).to.equal(true);
   });
 
   it('cannot read a host cwd file through a relative path', async () => {
-    // Reading the secret by the same relative path a leaking import would use
-    // must fail, because the sandbox cwd does not contain it.
+    // The same relative path a leaking import would use must fail to read.
     let thrown: any;
     try {
       await asyncExec(`cat "./${secretName}"`, '{}', MAX_BUFFER);
@@ -139,7 +133,7 @@ describe('asyncExec compiler cwd sandbox (import path leak)', () => {
     const after = fs
       .readdirSync(os.tmpdir())
       .filter((d) => d.startsWith('sourcify-compiler-'));
-    // No new sourcify-compiler-* dir is left behind after a successful run.
+    // No temp dir left behind after a run.
     expect(after.length).to.be.at.most(before.length);
   });
 });

--- a/packages/compilers/test/solidityCompiler.spec.ts
+++ b/packages/compilers/test/solidityCompiler.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import {
+  findSolcPlatform,
   getSolcExecutable,
   getSolcJs,
   useSolidityCompiler,
@@ -8,6 +9,7 @@ import { COMPILER_TIMEOUT_CODE } from '@ethereum-sourcify/compilers-types';
 import earlyCompilerInput from './utils/pre-v0.4.0-input.json';
 import { keccak256 } from 'ethers';
 import path from 'path';
+import fs from 'fs';
 
 describe('Verify Solidity Compiler', () => {
   const compilersPath = path.join('/tmp', 'compilers-solc-repo');
@@ -213,5 +215,85 @@ describe('Verify Solidity Compiler', () => {
     expect(compiledHash).equals(
       '0xc778f3d42ce4a7ee21a2e93d45265cf771e5970e0e36f882310f4491d0ca889d',
     );
+  });
+
+  /**
+   * Native solc --standard-json resolves missing imports against cwd (allowed
+   * dirs: "."). From solc 0.8.8 onward this can read host files and leak their
+   * contents through ParserError.formattedMessage (returned via compiler_error).
+   * solc <=0.8.7 rejects the same imports as outside allowed directories.
+   */
+  it('Should not leak host cwd files through native solc import errors', async function () {
+    // Force the native binary path used in production (linux-amd64 / macosx-amd64).
+    // On darwin-arm64 findSolcPlatform() is false; temporarily report x64 so the
+    // universal macos binary is selected (same as production's native path).
+    const realArch = process.arch;
+    const realPlatform = process.platform;
+    if (realPlatform === 'darwin' && realArch === 'arm64') {
+      Object.defineProperty(process, 'arch', {
+        value: 'x64',
+        configurable: true,
+        writable: true,
+      });
+    }
+    if (!findSolcPlatform()) {
+      Object.defineProperty(process, 'arch', {
+        value: realArch,
+        configurable: true,
+        writable: true,
+      });
+      this.skip();
+    }
+
+    const secretMarker = `LEAK_SECRET_VALUE_${process.pid}_${Date.now()}`;
+    const secretFileName = `.sourcify-solc-cwd-leak-test-${process.pid}`;
+    const secretFilePath = path.join(process.cwd(), secretFileName);
+    fs.writeFileSync(secretFilePath, `${secretMarker}=super-secret\n`, 'utf8');
+
+    try {
+      try {
+        await useSolidityCompiler(
+          compilersPath,
+          solJsonRepo,
+          '0.8.28+commit.7893614a',
+          {
+            language: 'Solidity',
+            sources: {
+              'Contract.sol': {
+                content: `// SPDX-License-Identifier: MIT\npragma solidity ^0.8.0;\nimport "./${secretFileName}";\ncontract C {}\n`,
+              },
+            },
+            settings: {
+              outputSelection: {
+                '*': {
+                  '*': ['evm.bytecode'],
+                },
+              },
+            },
+          },
+        );
+        expect.fail('Expected compilation to fail for non-Solidity import');
+      } catch (e: any) {
+        const serialized = `${e?.message || ''}\n${JSON.stringify(e?.errors || [])}`;
+        expect(
+          serialized.includes(secretMarker),
+          `Compiler error leaked host file contents: ${serialized}`,
+        ).to.equal(false);
+        // Still a normal missing-import / parse failure, not a crash.
+        expect(e.message.startsWith('Compiler error')).to.equal(true);
+      }
+    } finally {
+      fs.rmSync(secretFilePath, { force: true });
+      Object.defineProperty(process, 'arch', {
+        value: realArch,
+        configurable: true,
+        writable: true,
+      });
+      Object.defineProperty(process, 'platform', {
+        value: realPlatform,
+        configurable: true,
+        writable: true,
+      });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Native `solc --standard-json` still resolves missing imports against the process cwd (allowed base path `"."`). From **solc 0.8.8** onward, a user-supplied contract can `import` relative host files (e.g. `./.env`, `package.json`); `ParserError.formattedMessage` then echoes file contents through `compiler_error` API responses.

- `solc <= 0.8.7` rejects the same imports as outside allowed directories (no content leak)
- solc-js is unaffected (no filesystem import callback)
- Production Linux prefers the native binary for solc `>= 0.4.10`, so this path is reachable in normal verification

### Fix

- Run native **solc** in an empty temp directory and delete it after compilation
- Resolve the solc binary path before changing cwd so a relative `solcRepo` still works

### Out of scope

**Vyper is not changed.** Probing `vyper --standard-json` (0.3.7 / 0.3.10 / 0.4.0) with HOST cwd bait files vs empty cwd showed:
- no host-file content in compiler errors
- HOST vs EMPTY behavior identical (`ModuleNotFound` / cannot locate interface)
- so this is a solc-specific issue, not applied to Vyper

## Validation

```bash
# from packages/compilers
npx mocha --exit --grep 'Should not leak host cwd files' test/solidityCompiler.spec.ts
npx mocha --exit test/solidityCompiler.spec.ts
```