### PR TITLE
fix(compilers): confine Fe source paths to the compilation temp dir

### DIFF
--- a/packages/compilers/src/lib/feCompiler.ts
+++ b/packages/compilers/src/lib/feCompiler.ts
@@ -108,6 +108,47 @@ async function fetchAndSaveFe(
 }
 
 /**
+ * Resolve a user-provided source path strictly inside baseDir.
+ * Rejects absolute paths and any `..` traversal that would escape the
+ * compilation temp directory (`path.join` alone is not sufficient).
+ */
+export function resolveSafeSourcePath(
+  baseDir: string,
+  sourcePath: string,
+): string {
+  if (!sourcePath || sourcePath.includes('\0')) {
+    throw new Error(`Invalid Fe source path: ${JSON.stringify(sourcePath)}`);
+  }
+  if (path.isAbsolute(sourcePath)) {
+    throw new Error(`Fe source path must be relative: ${sourcePath}`);
+  }
+  // Disallow backslashes so mixed-separator inputs cannot sneak past checks
+  // on POSIX hosts (where `\` is a normal filename character).
+  if (sourcePath.includes('\\')) {
+    throw new Error(
+      `Fe source path must use POSIX separators ("/"): ${sourcePath}`,
+    );
+  }
+
+  const resolvedBase = path.resolve(baseDir);
+  const resolvedPath = path.resolve(baseDir, sourcePath);
+  const relative = path.relative(resolvedBase, resolvedPath);
+
+  if (
+    relative === '' ||
+    relative === '..' ||
+    relative.startsWith(`..${path.sep}`) ||
+    path.isAbsolute(relative)
+  ) {
+    throw new Error(
+      `Fe source path escapes compilation directory: ${sourcePath}`,
+    );
+  }
+
+  return resolvedPath;
+}
+
+/**
  * Compiles Fe source files by:
  * 1. Scaffolding a unique temp ingot directory
  * 2. Running `fe build`
@@ -144,7 +185,7 @@ export async function useFeCompiler(
 
     // Write source files (sourcePaths already have src/ prefix, e.g. 'src/lib.fe')
     for (const [sourcePath, source] of Object.entries(feJsonInput.sources)) {
-      const fullPath = path.join(tmpDir, sourcePath);
+      const fullPath = resolveSafeSourcePath(tmpDir, sourcePath);
       await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
       await fs.promises.writeFile(fullPath, source.content);
     }

--- a/packages/compilers/test/feCompiler.spec.ts
+++ b/packages/compilers/test/feCompiler.spec.ts
@@ -2,9 +2,12 @@ import { expect } from 'chai';
 import {
   findFePlatform,
   getFeExecutable,
+  resolveSafeSourcePath,
   useFeCompiler,
 } from '../src/lib/feCompiler';
 import { CompilerError } from '../src/lib/common';
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
 
 describe('Verify Fe Compiler', () => {
@@ -174,5 +177,99 @@ pub contract Counter {
     expect(counter.evm.bytecode.object).to.be.a('string').that.is.not.empty;
     expect(counter.evm.deployedBytecode.object).to.be.a('string').that.is.not
       .empty;
+  });
+
+  describe('resolveSafeSourcePath', () => {
+    const baseDir = path.join(os.tmpdir(), 'fe-safe-path-base');
+
+    it('allows normal relative source paths under the base dir', () => {
+      const resolved = resolveSafeSourcePath(baseDir, 'src/lib.fe');
+      expect(resolved).to.equal(path.resolve(baseDir, 'src/lib.fe'));
+    });
+
+    it('allows nested relative source paths under the base dir', () => {
+      const resolved = resolveSafeSourcePath(baseDir, 'src/nested/counter.fe');
+      expect(resolved).to.equal(path.resolve(baseDir, 'src/nested/counter.fe'));
+    });
+
+    it('rejects absolute source paths', () => {
+      expect(() => resolveSafeSourcePath(baseDir, '/tmp/evil.fe')).to.throw(
+        'must be relative',
+      );
+    });
+
+    it('rejects parent-directory traversal', () => {
+      expect(() =>
+        resolveSafeSourcePath(baseDir, 'src/../../outside.fe'),
+      ).to.throw('escapes compilation directory');
+    });
+
+    it('rejects deep traversal that collapses outside the base dir', () => {
+      expect(() =>
+        resolveSafeSourcePath(
+          baseDir,
+          `src/${'../'.repeat(32)}tmp/sourcify-fe-escaped.fe`,
+        ),
+      ).to.throw('escapes compilation directory');
+    });
+
+    it('rejects backslash separators', () => {
+      expect(() =>
+        resolveSafeSourcePath(baseDir, 'src\\..\\..\\outside.fe'),
+      ).to.throw('POSIX separators');
+    });
+
+    it('rejects empty and null-byte paths', () => {
+      expect(() => resolveSafeSourcePath(baseDir, '')).to.throw(
+        'Invalid Fe source path',
+      );
+      expect(() => resolveSafeSourcePath(baseDir, 'src/lib\0.fe')).to.throw(
+        'Invalid Fe source path',
+      );
+    });
+  });
+
+  it('Should reject path-traversing source keys without writing outside tmp', async function () {
+    if (!findFePlatform()) {
+      this.skip();
+    }
+
+    const markerPath = path.join(
+      os.tmpdir(),
+      `sourcify-fe-path-traversal-${process.pid}-${Date.now()}`,
+    );
+    // Enough ../ segments to escape any temp directory layout.
+    const traversalKey = `src/${'../'.repeat(64)}${path
+      .relative(path.parse(os.tmpdir()).root, markerPath)
+      .split(path.sep)
+      .join('/')}`;
+
+    expect(fs.existsSync(markerPath)).to.equal(false);
+
+    try {
+      await useFeCompiler(feRepoPath, version, {
+        language: 'Fe',
+        settings: {},
+        sources: {
+          [traversalKey]: {
+            content: 'path-traversal-poc',
+          },
+        },
+      });
+      expect.fail('Expected path traversal to be rejected');
+    } catch (error: any) {
+      expect(error).to.be.instanceOf(Error);
+      expect(error.message).to.match(
+        /escapes compilation directory|must be relative|Invalid Fe source path/,
+      );
+    } finally {
+      const leaked = fs.existsSync(markerPath);
+      if (leaked) {
+        fs.rmSync(markerPath, { force: true });
+      }
+      expect(leaked, 'traversal must not write outside the temp dir').to.equal(
+        false,
+      );
+    }
   });
 });

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -219,6 +219,41 @@ export function validateMetadata(
   next();
 }
 
+/**
+ * Reject absolute paths and `..` segments in Fe source keys.
+ * Complements path confinement in @ethereum-sourcify/compilers' useFeCompiler,
+ * which writes sources into a temp ingot directory.
+ */
+function assertSafeFeSourcePath(sourcePath: string) {
+  if (!sourcePath || sourcePath.includes("\0")) {
+    throw new InvalidParametersError(
+      `Invalid Fe source path: ${JSON.stringify(sourcePath)}`,
+    );
+  }
+  if (sourcePath.includes("\\")) {
+    throw new InvalidParametersError(
+      `Fe source path must use POSIX separators ("/"): ${sourcePath}`,
+    );
+  }
+  if (sourcePath.startsWith("/") || /^[A-Za-z]:\//.test(sourcePath)) {
+    throw new InvalidParametersError(
+      `Fe source path must be relative: ${sourcePath}`,
+    );
+  }
+
+  const segments = sourcePath.split("/");
+  if (
+    segments.length === 0 ||
+    segments.some(
+      (segment) => segment === "" || segment === "." || segment === "..",
+    )
+  ) {
+    throw new InvalidParametersError(
+      `Fe source path contains invalid segment(s): ${sourcePath}`,
+    );
+  }
+}
+
 export function validateAndNormalizeFeInput(
   req: Request,
   res: Response,
@@ -250,6 +285,16 @@ export function validateAndNormalizeFeInput(
     req.body.stdJsonInput = { ...stdJsonInput, sources: normalized };
   }
 
+  // Validate final source keys after src/ normalization so traversal cannot
+  // sneak in via bare keys (e.g. "../etc/passwd" -> "src/../etc/passwd").
+  const finalSources = (req.body.stdJsonInput as FeJsonInput).sources as Record<
+    string,
+    { content: string }
+  >;
+  for (const sourcePath of Object.keys(finalSources)) {
+    assertSafeFeSourcePath(sourcePath);
+  }
+
   // Normalize contractIdentifier for Fe:
   // - Must include a colon, e.g. "src/lib.fe:Counter" or "src/counter.fe:Counter"
   // - Path must start with "src/" and end with ".fe"
@@ -272,6 +317,7 @@ export function validateAndNormalizeFeInput(
             '(e.g. "src/lib.fe:Counter" or "src/counter.fe:Counter").',
         );
       }
+      assertSafeFeSourcePath(contractPath);
       req.body.contractIdentifier = `${contractPath}:${contractName}`;
     }
   }


### PR DESCRIPTION
## Summary

Fe compilation wrote user-controlled `stdJsonInput.sources` keys with `path.join` into a temp ingot directory. Keys like `src/../../...` escaped that directory and could write arbitrary files as the server process user. Temp cleanup only removed the ingot dir, so escaped files persisted.

### Fix

- Resolve and reject escaping paths in `@ethereum-sourcify/compilers` before `mkdir`/`writeFile`
- Harden server Fe input middleware to reject absolute / `..` source keys early

## Impact

- Blocks arbitrary filesystem writes during Fe verification
- Valid relative Fe source keys (e.g. `src/lib.fe`) unchanged

## Validation

```bash
# from packages/compilers
npx mocha --exit test/feCompiler.spec.ts
```