### PR TITLE
fix(compilers): reject path-like compiler versions before artifact write

### DIFF
--- a/packages/compilers/src/lib/common.ts
+++ b/packages/compilers/src/lib/common.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import { exec } from 'child_process';
 import { logDebug, logError, logSilly } from '../logger';
 import type { OutputError } from '@ethereum-sourcify/compilers-types';
@@ -54,6 +55,46 @@ export async function fetchWithBackoff(
     }
   }
   throw new Error(`Failed fetching ${resource}`);
+}
+
+/**
+ * Build a compiler artifact path under repoPath from a version-derived fileName.
+ * Rejects versions/file names that could escape repoPath via path segments
+ * (e.g. "0.8.28/../../../tmp/pwn"), which OpenAPI's loose CompilerVersion
+ * pattern would otherwise allow.
+ */
+export function resolveCompilerArtifactPath(
+  repoPath: string,
+  fileName: string,
+  version: string,
+): string {
+  const isUnsafePathInput = (value: string): boolean => {
+    if (value.includes('\0') || value.includes('..')) {
+      return true;
+    }
+    // Reject any path separator (POSIX or Windows), independent of host OS.
+    if (value.includes('/') || value.includes('\\')) {
+      return true;
+    }
+    if (path.basename(value) !== value) {
+      return true;
+    }
+    return false;
+  };
+
+  if (isUnsafePathInput(version) || isUnsafePathInput(fileName)) {
+    throw new Error(`Invalid compiler version: ${JSON.stringify(version)}`);
+  }
+
+  const resolvedRepo = path.resolve(repoPath);
+  const resolvedPath = path.resolve(resolvedRepo, fileName);
+  const repoPrefix = resolvedRepo.endsWith(path.sep)
+    ? resolvedRepo
+    : `${resolvedRepo}${path.sep}`;
+  if (resolvedPath !== resolvedRepo && !resolvedPath.startsWith(repoPrefix)) {
+    throw new Error(`Invalid compiler version: ${JSON.stringify(version)}`);
+  }
+  return resolvedPath;
 }
 
 export function asyncExec(

--- a/packages/compilers/src/lib/feCompiler.ts
+++ b/packages/compilers/src/lib/feCompiler.ts
@@ -3,7 +3,11 @@ import fs from 'fs';
 import os from 'os';
 import { spawnSync } from 'child_process';
 import semver from 'semver';
-import { CompilerError, fetchWithBackoff } from './common';
+import {
+  CompilerError,
+  fetchWithBackoff,
+  resolveCompilerArtifactPath,
+} from './common';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
 import type { FeJsonInput, FeOutput } from '@ethereum-sourcify/compilers-types';
 import type { JsonFragment } from 'ethers';
@@ -40,7 +44,7 @@ export async function getFeExecutable(
   version: string,
 ): Promise<string> {
   const fileName = `fe-${version}-${platform}`;
-  const fePath = path.join(feRepoPath, fileName);
+  const fePath = resolveCompilerArtifactPath(feRepoPath, fileName, version);
   if (validateFePath(fePath)) {
     return fePath;
   }

--- a/packages/compilers/src/lib/solidityCompiler.ts
+++ b/packages/compilers/src/lib/solidityCompiler.ts
@@ -6,7 +6,12 @@ import semver from 'semver';
 import type { WorkerOptions } from 'worker_threads';
 import { Worker } from 'worker_threads';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
-import { asyncExec, CompilerError, fetchWithBackoff } from './common';
+import {
+  asyncExec,
+  CompilerError,
+  fetchWithBackoff,
+  resolveCompilerArtifactPath,
+} from './common';
 import type {
   SolidityJsonInput,
   SolidityOutput,
@@ -141,7 +146,7 @@ export async function getSolcExecutable(
   version: string,
 ): Promise<string | null> {
   const fileName = `solc-${platform}-v${version}`;
-  const solcPath = path.join(solcRepoPath, fileName);
+  const solcPath = resolveCompilerArtifactPath(solcRepoPath, fileName, version);
   if (fs.existsSync(solcPath) && validateSolcPath(solcPath)) {
     logDebug('Found existing solc', { version, platform, solcPath });
     return solcPath;

--- a/packages/compilers/src/lib/vyperCompiler.ts
+++ b/packages/compilers/src/lib/vyperCompiler.ts
@@ -2,7 +2,12 @@
 import path from 'path';
 import fs from 'fs';
 import { spawnSync } from 'child_process';
-import { asyncExec, CompilerError, fetchWithBackoff } from './common';
+import {
+  asyncExec,
+  CompilerError,
+  fetchWithBackoff,
+  resolveCompilerArtifactPath,
+} from './common';
 import { logDebug, logError, logInfo, logWarn } from '../logger';
 import type {
   VyperJsonInput,
@@ -107,7 +112,11 @@ export async function getVyperExecutable(
   version: string,
 ): Promise<string> {
   const fileName = `vyper.${version}.${platform}`;
-  const vyperPath = path.join(vyperRepoPath, fileName);
+  const vyperPath = resolveCompilerArtifactPath(
+    vyperRepoPath,
+    fileName,
+    version,
+  );
   if (validateVyperPath(vyperPath)) {
     return vyperPath;
   }

--- a/packages/compilers/test/compilerArtifactPath.spec.ts
+++ b/packages/compilers/test/compilerArtifactPath.spec.ts
@@ -1,0 +1,58 @@
+import { expect } from 'chai';
+import path from 'path';
+import { resolveCompilerArtifactPath } from '../src/lib/common';
+import { getSolcExecutable } from '../src/lib/solidityCompiler';
+
+describe('resolveCompilerArtifactPath', () => {
+  const repo = path.join('/tmp', 'compilers-artifact-repo');
+
+  it('accepts normal solc version file names', () => {
+    const version = '0.8.28+commit.7893614a';
+    const fileName = `solc-linux-amd64-v${version}`;
+    const resolved = resolveCompilerArtifactPath(repo, fileName, version);
+    expect(resolved).to.equal(path.resolve(repo, fileName));
+  });
+
+  it('rejects versions containing path separators', () => {
+    const version = '0.8.28/../../../tmp/pwn';
+    const fileName = `solc-linux-amd64-v${version}`;
+    expect(() => resolveCompilerArtifactPath(repo, fileName, version)).to.throw(
+      /Invalid compiler version/,
+    );
+  });
+
+  it('rejects versions containing ..', () => {
+    expect(() =>
+      resolveCompilerArtifactPath(
+        repo,
+        'solc-linux-amd64-v0.8.28..x',
+        '0.8.28..x',
+      ),
+    ).to.throw(/Invalid compiler version/);
+  });
+
+  it('rejects backslash separators in version', () => {
+    const version = '0.8.28\\..\\..\\pwn';
+    const fileName = `solc-linux-amd64-v${version}`;
+    expect(() => resolveCompilerArtifactPath(repo, fileName, version)).to.throw(
+      /Invalid compiler version/,
+    );
+  });
+});
+
+describe('getSolcExecutable path safety', () => {
+  const compilersPath = path.join('/tmp', 'compilers-solc-repo-path-safety');
+
+  it('does not fetch or write when version escapes the repo', async () => {
+    try {
+      await getSolcExecutable(
+        compilersPath,
+        'linux-amd64',
+        '0.8.28/../../../tmp/pwn',
+      );
+      expect.fail('Expected invalid version to be rejected');
+    } catch (e: any) {
+      expect(e.message).to.match(/Invalid compiler version/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

OpenAPI `CompilerVersion` uses `^v?\d+\.\d+\.\d+.*$`, so values like `0.8.28/../../../tmp/pwn` pass validation. `path.join(solcRepo, \`solc-${platform}-v${version}\`)` can then escape the compiler cache directory.

Successful arbitrary write still requires a 200 from the compiler CDN (URLs are percent-encoded, so this usually 404s), but path construction is unsafe and should be rejected early.

### Fix

- Shared `resolveCompilerArtifactPath` helper rejects separators / `..` and ensures the resolved path stays under the repo root
- Used by solc, vyper, and fe executable getters
- Unit tests for accept/reject cases and `getSolcExecutable` early throw

## Related

- Sibling hardening: Fe source-path write confinement, solc/vyper cwd sandbox (#2920)

## Validation

```bash
# from packages/compilers
npx mocha --exit test/compilerArtifactPath.spec.ts
```