### PR TITLE
feat: extract metadata to compiled_contracts_metadata

### DIFF
--- a/services/database/migrations/20260816133800_add_compiled_contracts_metadata.sql
+++ b/services/database/migrations/20260816133800_add_compiled_contracts_metadata.sql
@@ -1,0 +1,22 @@
+-- migrate:up
+
+CREATE TABLE compiled_contracts_metadata (
+  compilation_id uuid PRIMARY KEY REFERENCES compiled_contracts(id) ON DELETE CASCADE,
+  metadata json NOT NULL
+);
+
+-- Backfill metadata from sourcify_matches.
+-- We use DISTINCT ON (compilation_id) to ensure we only keep the "first" metadata variant per compilation, 
+-- which matches the logic used for source files. We also ensure we only insert metadata that is NOT NULL.
+INSERT INTO compiled_contracts_metadata (compilation_id, metadata)
+SELECT DISTINCT ON (vc.compilation_id)
+  vc.compilation_id,
+  sm.metadata
+FROM sourcify_matches sm
+JOIN verified_contracts vc ON vc.id = sm.verified_contract_id
+WHERE sm.metadata IS NOT NULL
+ON CONFLICT (compilation_id) DO NOTHING;
+
+-- migrate:down
+
+DROP TABLE IF EXISTS compiled_contracts_metadata;

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -987,6 +987,16 @@ CREATE TABLE public.compiled_contracts (
 
 
 --
+-- Name: compiled_contracts_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.compiled_contracts_metadata (
+    compilation_id uuid NOT NULL,
+    metadata json NOT NULL
+);
+
+
+--
 -- Name: compiled_contracts_signatures; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1315,6 +1325,14 @@ ALTER TABLE ONLY public.verified_contracts ALTER COLUMN id SET DEFAULT nextval('
 
 ALTER TABLE ONLY public.code
     ADD CONSTRAINT code_pkey PRIMARY KEY (code_hash);
+
+
+--
+-- Name: compiled_contracts_metadata compiled_contracts_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compiled_contracts_metadata
+    ADD CONSTRAINT compiled_contracts_metadata_pkey PRIMARY KEY (compilation_id);
 
 
 --
@@ -2075,6 +2093,14 @@ ALTER TABLE ONLY public.compiled_contracts
 
 
 --
+-- Name: compiled_contracts_metadata compiled_contracts_metadata_compilation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compiled_contracts_metadata
+    ADD CONSTRAINT compiled_contracts_metadata_compilation_id_fkey FOREIGN KEY (compilation_id) REFERENCES public.compiled_contracts(id) ON DELETE CASCADE;
+
+
+--
 -- Name: compiled_contracts compiled_contracts_runtime_code_hash_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2210,4 +2236,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260309080000'),
     ('20260527081526'),
     ('20260527085036'),
-    ('20260527085037');
+    ('20260527085037'),
+    ('20260816133800');

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -117,7 +117,7 @@ export default abstract class AbstractDatabaseService {
           sourcesInformation: databaseColumns.sourcesInformation,
           compilation_id: compiledContractId,
         });
-        
+
         await this.database.insertCompiledContractMetadata(client, {
           compilation_id: compiledContractId,
           metadata: databaseColumns.sourcifyMatch.metadata,

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -117,6 +117,11 @@ export default abstract class AbstractDatabaseService {
           sourcesInformation: databaseColumns.sourcesInformation,
           compilation_id: compiledContractId,
         });
+        
+        await this.database.insertCompiledContractMetadata(client, {
+          compilation_id: compiledContractId,
+          metadata: databaseColumns.sourcifyMatch.metadata,
+        });
       }
 
       // insert new recompiled contract with newly added contract and compiledContract
@@ -213,6 +218,11 @@ export default abstract class AbstractDatabaseService {
         await this.database.insertCompiledContractsSources(client, {
           sourcesInformation: databaseColumns.sourcesInformation,
           compilation_id: compiledContractId,
+        });
+
+        await this.database.insertCompiledContractMetadata(client, {
+          compilation_id: compiledContractId,
+          metadata: databaseColumns.sourcifyMatch.metadata,
         });
       }
 

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -120,7 +120,7 @@ export default abstract class AbstractDatabaseService {
 
         await this.database.insertCompiledContractMetadata(client, {
           compilation_id: compiledContractId,
-          metadata: databaseColumns.sourcifyMatch.metadata,
+          metadata: databaseColumns.metadata,
         });
       }
 
@@ -222,7 +222,7 @@ export default abstract class AbstractDatabaseService {
 
         await this.database.insertCompiledContractMetadata(client, {
           compilation_id: compiledContractId,
-          metadata: databaseColumns.sourcifyMatch.metadata,
+          metadata: databaseColumns.metadata,
         });
       }
 

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -212,7 +212,8 @@ ${
       properties.includes("std_json_input") ||
       properties.includes("function_signatures") ||
       properties.includes("event_signatures") ||
-      properties.includes("error_signatures")
+      properties.includes("error_signatures") ||
+      properties.includes("metadata")
         ? `GROUP BY sourcify_matches.id,
         verified_contracts.id,
         compiled_contracts.id,
@@ -221,7 +222,11 @@ ${
         onchain_runtime_code.code_hash,
         onchain_creation_code.code_hash,
         recompiled_runtime_code.code_hash,
-        recompiled_creation_code.code_hash`
+        recompiled_creation_code.code_hash${
+          properties.includes("metadata")
+            ? ",\n        compiled_contracts_metadata.metadata"
+            : ""
+        }`
         : "";
 
     return await this.pool.query(
@@ -240,6 +245,11 @@ ${
         LEFT JOIN ${this.schema}.code as onchain_creation_code ON onchain_creation_code.code_hash = contracts.creation_code_hash
         LEFT JOIN ${this.schema}.code as recompiled_runtime_code ON recompiled_runtime_code.code_hash = compiled_contracts.runtime_code_hash
         LEFT JOIN ${this.schema}.code as recompiled_creation_code ON recompiled_creation_code.code_hash = compiled_contracts.creation_code_hash
+${
+  properties.includes("metadata")
+    ? `LEFT JOIN ${this.schema}.compiled_contracts_metadata ON compiled_contracts_metadata.compilation_id = verified_contracts.compilation_id`
+    : ""
+}
 ${
   properties.includes("function_signatures") ||
   properties.includes("event_signatures") ||

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -212,8 +212,7 @@ ${
       properties.includes("std_json_input") ||
       properties.includes("function_signatures") ||
       properties.includes("event_signatures") ||
-      properties.includes("error_signatures") ||
-      properties.includes("metadata")
+      properties.includes("error_signatures")
         ? `GROUP BY sourcify_matches.id,
         verified_contracts.id,
         compiled_contracts.id,
@@ -222,11 +221,7 @@ ${
         onchain_runtime_code.code_hash,
         onchain_creation_code.code_hash,
         recompiled_runtime_code.code_hash,
-        recompiled_creation_code.code_hash${
-          properties.includes("metadata")
-            ? ",\n        compiled_contracts_metadata.metadata"
-            : ""
-        }`
+        recompiled_creation_code.code_hash`
         : "";
 
     return await this.pool.query(

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -165,7 +165,7 @@ export class Database {
           sourcify_matches.created_at,
           sourcify_matches.creation_match,
           sourcify_matches.runtime_match,
-          sourcify_matches.metadata,
+          COALESCE(compiled_contracts_metadata.metadata, sourcify_matches.metadata) as metadata,
           verified_contracts.creation_values,
           verified_contracts.runtime_values,
           verified_contracts.compilation_id,
@@ -177,6 +177,7 @@ export class Database {
         FROM ${this.schema}.sourcify_matches
         JOIN ${this.schema}.verified_contracts ON verified_contracts.id = sourcify_matches.verified_contract_id
         JOIN ${this.schema}.compiled_contracts ON compiled_contracts.id = verified_contracts.compilation_id
+        LEFT JOIN ${this.schema}.compiled_contracts_metadata ON compiled_contracts_metadata.compilation_id = verified_contracts.compilation_id
         JOIN ${this.schema}.contract_deployments ON 
           contract_deployments.id = verified_contracts.deployment_id 
           AND contract_deployments.chain_id = $1 
@@ -1238,5 +1239,20 @@ ${
         [hash],
       );
     }
+  }
+
+  async insertCompiledContractMetadata(
+    poolClient: PoolClient,
+    {
+      compilation_id,
+      metadata,
+    }: { compilation_id: string; metadata: any },
+  ) {
+    await poolClient.query(
+      `INSERT INTO ${this.schema}.compiled_contracts_metadata (compilation_id, metadata)
+       VALUES ($1, $2)
+       ON CONFLICT (compilation_id) DO NOTHING`,
+      [compilation_id, metadata],
+    );
   }
 }

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -1255,6 +1255,8 @@ ${
     poolClient: PoolClient,
     { compilation_id, metadata }: { compilation_id: string; metadata: any },
   ) {
+    if (metadata == null) return;
+
     await poolClient.query(
       `INSERT INTO ${this.schema}.compiled_contracts_metadata (compilation_id, metadata)
        VALUES ($1, $2)

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -1243,10 +1243,7 @@ ${
 
   async insertCompiledContractMetadata(
     poolClient: PoolClient,
-    {
-      compilation_id,
-      metadata,
-    }: { compilation_id: string; metadata: any },
+    { compilation_id, metadata }: { compilation_id: string; metadata: any },
   ) {
     await poolClient.query(
       `INSERT INTO ${this.schema}.compiled_contracts_metadata (compilation_id, metadata)

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -221,7 +221,12 @@ ${
         onchain_runtime_code.code_hash,
         onchain_creation_code.code_hash,
         recompiled_runtime_code.code_hash,
-        recompiled_creation_code.code_hash`
+        recompiled_creation_code.code_hash${
+          properties.includes("metadata") ||
+          properties.includes("std_json_output")
+            ? ",\n        compiled_contracts_metadata.compilation_id"
+            : ""
+        }`
         : "";
 
     return await this.pool.query(
@@ -241,7 +246,7 @@ ${
         LEFT JOIN ${this.schema}.code as recompiled_runtime_code ON recompiled_runtime_code.code_hash = compiled_contracts.runtime_code_hash
         LEFT JOIN ${this.schema}.code as recompiled_creation_code ON recompiled_creation_code.code_hash = compiled_contracts.creation_code_hash
 ${
-  properties.includes("metadata")
+  properties.includes("metadata") || properties.includes("std_json_output")
     ? `LEFT JOIN ${this.schema}.compiled_contracts_metadata ON compiled_contracts_metadata.compilation_id = verified_contracts.compilation_id`
     : ""
 }

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -236,6 +236,7 @@ export interface DatabaseColumns {
     "id" | "compilation_id" | "deployment_id"
   >;
   sourcesInformation: SourceInformation[];
+  metadata: any;
 }
 
 export type GetVerifiedContractByChainAndAddressResult =
@@ -923,6 +924,7 @@ export async function getDatabaseColumnsFromVerification(
       runtime_metadata_match,
       creation_metadata_match,
     },
+    metadata: (verification.compilation as any).metadata,
   };
 }
 

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -435,7 +435,7 @@ export const STORED_PROPERTIES_TO_SELECTORS = {
   name: "compiled_contracts.name",
   fully_qualified_name: "compiled_contracts.fully_qualified_name",
   abi: "compiled_contracts.compilation_artifacts->'abi' as abi",
-  metadata: "sourcify_matches.metadata",
+  metadata: "COALESCE(compiled_contracts_metadata.metadata, sourcify_matches.metadata) as metadata",
   storage_layout:
     "compiled_contracts.compilation_artifacts->'storageLayout' as storage_layout",
   transient_storage_layout:
@@ -461,7 +461,7 @@ export const STORED_PROPERTIES_TO_SELECTORS = {
       json_build_object(
         split_part(compiled_contracts.fully_qualified_name, ':', -1), json_build_object(
           'abi', compiled_contracts.compilation_artifacts->'abi',
-          'metadata', cast(sourcify_matches.metadata as text),
+          'metadata', cast(COALESCE(compiled_contracts_metadata.metadata, sourcify_matches.metadata) as text),
           'userdoc', compiled_contracts.compilation_artifacts->'userdoc',
           'devdoc', compiled_contracts.compilation_artifacts->'devdoc',
           'storageLayout', compiled_contracts.compilation_artifacts->'storageLayout',

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -435,7 +435,8 @@ export const STORED_PROPERTIES_TO_SELECTORS = {
   name: "compiled_contracts.name",
   fully_qualified_name: "compiled_contracts.fully_qualified_name",
   abi: "compiled_contracts.compilation_artifacts->'abi' as abi",
-  metadata: "COALESCE(compiled_contracts_metadata.metadata, sourcify_matches.metadata) as metadata",
+  metadata:
+    "COALESCE(compiled_contracts_metadata.metadata, sourcify_matches.metadata) as metadata",
   storage_layout:
     "compiled_contracts.compilation_artifacts->'storageLayout' as storage_layout",
   transient_storage_layout:


### PR DESCRIPTION
Fixes #2924 by deduplicating JSON metadata into a separate `compiled_contracts_metadata` side table. This dramatically reduces table bloat in `sourcify_matches` caused by multiple networks sharing identical compiled contract JSON structures. The reads are gracefully degraded via COALESCE, allowing zero-downtime database migration.