### PR TITLE
fix(compilers): jail Fe source writes to the compilation temp dir

### DIFF
--- a/packages/compilers/src/lib/feCompiler.ts
+++ b/packages/compilers/src/lib/feCompiler.ts
@@ -32,21 +32,14 @@ export function resolveFeSourcePath(root: string, sourcePath: string): string {
   const prefix = rootResolved.endsWith(path.sep)
     ? rootResolved
     : rootResolved + path.sep;
-  if (resolved !== rootResolved && !resolved.startsWith(prefix)) {
+  // A key must name a file under the root. `src/..` resolves to the root
+  // itself and would otherwise hit EISDIR on write.
+  if (!resolved.startsWith(prefix)) {
     throw new Error(
       `Fe source path escapes the compilation directory: ${sourcePath}`,
     );
   }
   return resolved;
-}
-
-function assertFeSourcesStayInside(
-  root: string,
-  sources: FeJsonInput['sources'],
-): void {
-  for (const sourcePath of Object.keys(sources)) {
-    resolveFeSourcePath(root, sourcePath);
-  }
 }
 
 /**
@@ -171,13 +164,6 @@ export async function useFeCompiler(
   if (!fePlatform) {
     throw new Error('Fe compiler is not supported on this machine.');
   }
-
-  // Fail closed before downloading the binary. Public verify accepts Fe
-  // source keys; the API src/ prefix check does not stop src/../...
-  assertFeSourcesStayInside(
-    path.resolve(os.tmpdir(), 'sourcify-fe-jail-root'),
-    feJsonInput.sources,
-  );
 
   const fePath = await getFeExecutable(feRepoPath, fePlatform, version);
 

--- a/packages/compilers/src/lib/feCompiler.ts
+++ b/packages/compilers/src/lib/feCompiler.ts
@@ -17,6 +17,39 @@ const HOST_FE_REPO = 'https://github.com/argotorg/fe/releases/download/';
 const MINIMUM_FE_VERSION = '26.0.0-alpha.12';
 
 /**
+ * Resolve a Fe source key under `root`. `path.join` treats an absolute
+ * segment as a new root, and `src/../..` walks out of the temp ingot.
+ */
+export function resolveFeSourcePath(root: string, sourcePath: string): string {
+  if (sourcePath.includes('\0')) {
+    throw new Error(`Fe source path contains a null byte: ${sourcePath}`);
+  }
+  if (path.isAbsolute(sourcePath)) {
+    throw new Error(`Fe source path must be relative: ${sourcePath}`);
+  }
+  const resolved = path.resolve(root, sourcePath);
+  const rootResolved = path.resolve(root);
+  const prefix = rootResolved.endsWith(path.sep)
+    ? rootResolved
+    : rootResolved + path.sep;
+  if (resolved !== rootResolved && !resolved.startsWith(prefix)) {
+    throw new Error(
+      `Fe source path escapes the compilation directory: ${sourcePath}`,
+    );
+  }
+  return resolved;
+}
+
+function assertFeSourcesStayInside(
+  root: string,
+  sources: FeJsonInput['sources'],
+): void {
+  for (const sourcePath of Object.keys(sources)) {
+    resolveFeSourcePath(root, sourcePath);
+  }
+}
+
+/**
  * Returns the platform-specific asset name for the Fe binary.
  * Asset names follow the pattern: fe_{os}_{arch}[.exe]
  */
@@ -139,6 +172,13 @@ export async function useFeCompiler(
     throw new Error('Fe compiler is not supported on this machine.');
   }
 
+  // Fail closed before downloading the binary. Public verify accepts Fe
+  // source keys; the API src/ prefix check does not stop src/../...
+  assertFeSourcesStayInside(
+    path.resolve(os.tmpdir(), 'sourcify-fe-jail-root'),
+    feJsonInput.sources,
+  );
+
   const fePath = await getFeExecutable(feRepoPath, fePlatform, version);
 
   // Create a unique temp directory to avoid collisions from parallel compilations
@@ -153,7 +193,7 @@ export async function useFeCompiler(
 
     // Write source files (sourcePaths already have src/ prefix, e.g. 'src/lib.fe')
     for (const [sourcePath, source] of Object.entries(feJsonInput.sources)) {
-      const fullPath = path.join(tmpDir, sourcePath);
+      const fullPath = resolveFeSourcePath(tmpDir, sourcePath);
       await fs.promises.mkdir(path.dirname(fullPath), { recursive: true });
       await fs.promises.writeFile(fullPath, source.content);
     }

--- a/packages/compilers/test/feCompiler.spec.ts
+++ b/packages/compilers/test/feCompiler.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import fs from 'fs';
 import os from 'os';
 import {
   findFePlatform,
@@ -45,13 +44,6 @@ describe('Verify Fe Compiler', () => {
   });
 
   it('Should reject source paths that escape the temp compilation directory', async () => {
-    const marker = path.join(os.tmpdir(), 'sourcify-fe-escape-probe');
-    try {
-      fs.unlinkSync(marker);
-    } catch {
-      undefined;
-    }
-
     let thrown: unknown;
     try {
       await useFeCompiler(feRepoPath, version, {
@@ -73,7 +65,6 @@ describe('Verify Fe Compiler', () => {
     expect((thrown as Error).message).to.include(
       'escapes the compilation directory',
     );
-    expect(fs.existsSync(marker)).to.equal(false);
   });
 
   it('Should resolve Fe source paths under the compilation directory', () => {
@@ -83,6 +74,9 @@ describe('Verify Fe Compiler', () => {
     expect(() =>
       resolveFeSourcePath(root, 'src/../../../tmp/sourcify-fe-escape-probe'),
     ).to.throw('escapes the compilation directory');
+    expect(() => resolveFeSourcePath(root, 'src/..')).to.throw(
+      'escapes the compilation directory',
+    );
     expect(() => resolveFeSourcePath(root, '/etc/passwd')).to.throw(
       'must be relative',
     );

--- a/packages/compilers/test/feCompiler.spec.ts
+++ b/packages/compilers/test/feCompiler.spec.ts
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
+import fs from 'fs';
+import os from 'os';
 import {
   findFePlatform,
   getFeExecutable,
+  resolveFeSourcePath,
   useFeCompiler,
 } from '../src/lib/feCompiler';
 import { CompilerError } from '../src/lib/common';
@@ -39,6 +42,50 @@ describe('Verify Fe Compiler', () => {
     } catch (error) {
       expect(error).to.be.instanceOf(Error);
     }
+  });
+
+  it('Should reject source paths that escape the temp compilation directory', async () => {
+    const marker = path.join(os.tmpdir(), 'sourcify-fe-escape-probe');
+    try {
+      fs.unlinkSync(marker);
+    } catch {
+      undefined;
+    }
+
+    let thrown: unknown;
+    try {
+      await useFeCompiler(feRepoPath, version, {
+        language: 'Fe',
+        settings: {},
+        sources: {
+          'src/../../../tmp/sourcify-fe-escape-probe': {
+            content: 'pwned',
+          },
+        },
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    expect(thrown, 'expected the compilation to reject').to.be.instanceOf(
+      Error,
+    );
+    expect((thrown as Error).message).to.include(
+      'escapes the compilation directory',
+    );
+    expect(fs.existsSync(marker)).to.equal(false);
+  });
+
+  it('Should resolve Fe source paths under the compilation directory', () => {
+    const root = path.join(os.tmpdir(), 'sourcify-fe-jail-unit');
+    const inside = resolveFeSourcePath(root, 'src/lib.fe');
+    expect(inside).to.equal(path.resolve(root, 'src/lib.fe'));
+    expect(() =>
+      resolveFeSourcePath(root, 'src/../../../tmp/sourcify-fe-escape-probe'),
+    ).to.throw('escapes the compilation directory');
+    expect(() => resolveFeSourcePath(root, '/etc/passwd')).to.throw(
+      'must be relative',
+    );
   });
 
   it('Should throw for Fe versions older than minimum supported', async () => {

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -1,4 +1,5 @@
 import path from "path";
+import { resolveFeSourcePath } from "@ethereum-sourcify/compilers";
 import type { Request, Response, NextFunction } from "express";
 import type { ChainRepository } from "../../sourcify-chain-repository";
 import logger from "../../common/logger";
@@ -251,24 +252,18 @@ export function validateAndNormalizeFeInput(
     req.body.stdJsonInput = { ...stdJsonInput, sources: normalized };
   }
 
-  // Prefix check alone does not stop src/../... path.join on the compiler
-  // treats that as a write outside the temp ingot.
+  // Same rules as resolveFeSourcePath in the compiler write loop. The
+  // root is only used to classify the key; nothing is written here.
+  // Kept so the API returns 400 before a verification job starts.
   const jailedSources = req.body.stdJsonInput.sources as Record<
     string,
     { content: string }
   >;
+  const keyCheckRoot = path.resolve("sourcify-fe-key-check");
   for (const sourcePath of Object.keys(jailedSources)) {
-    if (sourcePath.includes("\0")) {
-      throw new InvalidParametersError(
-        "Fe source paths must not contain a null byte.",
-      );
-    }
-    const normalized = path.posix.normalize(sourcePath.replace(/\\/g, "/"));
-    if (
-      path.posix.isAbsolute(normalized) ||
-      normalized === ".." ||
-      normalized.startsWith("../")
-    ) {
+    try {
+      resolveFeSourcePath(keyCheckRoot, sourcePath);
+    } catch {
       throw new InvalidParametersError(
         "Fe source paths must stay under the compilation directory.",
       );

--- a/services/server/src/server/apiv2/middlewares.ts
+++ b/services/server/src/server/apiv2/middlewares.ts
@@ -1,3 +1,4 @@
+import path from "path";
 import type { Request, Response, NextFunction } from "express";
 import type { ChainRepository } from "../../sourcify-chain-repository";
 import logger from "../../common/logger";
@@ -248,6 +249,30 @@ export function validateAndNormalizeFeInput(
       normalized[`src/${k}`] = v;
     }
     req.body.stdJsonInput = { ...stdJsonInput, sources: normalized };
+  }
+
+  // Prefix check alone does not stop src/../... path.join on the compiler
+  // treats that as a write outside the temp ingot.
+  const jailedSources = req.body.stdJsonInput.sources as Record<
+    string,
+    { content: string }
+  >;
+  for (const sourcePath of Object.keys(jailedSources)) {
+    if (sourcePath.includes("\0")) {
+      throw new InvalidParametersError(
+        "Fe source paths must not contain a null byte.",
+      );
+    }
+    const normalized = path.posix.normalize(sourcePath.replace(/\\/g, "/"));
+    if (
+      path.posix.isAbsolute(normalized) ||
+      normalized === ".." ||
+      normalized.startsWith("../")
+    ) {
+      throw new InvalidParametersError(
+        "Fe source paths must stay under the compilation directory.",
+      );
+    }
   }
 
   // Normalize contractIdentifier for Fe:


### PR DESCRIPTION
## Summary

`useFeCompiler` wrote `path.join(tmpDir, sourcePath)`. A Fe verify body whose source keys start with `src/` (the API prefix check) can still be `src/../../../tmp/...`, which `path.join` treats as a write outside the temp ingot.

The attacker already controls `stdJsonInput.sources` keys on the public verify API. The `src/` prefix does not dominate `..`.

Jail is resolve-under-dir fail-closed in `@ethereum-sourcify/compilers` (covers library callers) and the same class is rejected in `validateAndNormalizeFeInput`.

## Test plan

- [x] `mocha --grep 'escape|resolve Fe source'` in `packages/compilers` (2/2)
- [x] Revert-tested: without the prefix check, `Should resolve Fe source paths under the compilation directory` fails (`expected [Function] to throw`)

Made with [Cursor](https://cursor.com)