### PR TITLE
fix(lib-sourcify): find all occurrences of repeated auxdata in bytecode

### DIFF
--- a/packages/lib-sourcify/src/Compilation/auxdataUtils.ts
+++ b/packages/lib-sourcify/src/Compilation/auxdataUtils.ts
@@ -137,6 +137,11 @@ export function findAuxdataPositions(
 
   // 3.  For every bytecodeDiffPosition, see if it hosts an compilerAuxdataDiff
   const resultAuxdatas: CompiledContractCborAuxdata = {};
+  // An auxdata from `legacyAssembly` can occur more than one time in the bytecode,
+  // e.g. when a contract embeds the same child bytecode in more than one location.
+  // We record each occurrence. Occurrences that go beyond the `legacyAssembly`
+  // entries get the next free keys.
+  let nextExtraAuxdataKey = compilerAuxdataDiffs.length + 1;
   let prevPos = -Infinity;
   for (const pos of bytecodeDiffPositions) {
     // Skip positions that are immediately consecutive to the previous one,
@@ -146,16 +151,17 @@ export function findAuxdataPositions(
       continue;
     }
 
-    // For each bytecodeDiffPosition, test every compilerAuxdataDiff that we haven't already mapped
+    // Test every compilerAuxdataDiff at this position. A diff that is not mapped
+    // gets its own key (i + 1). A diff that is already mapped shows one more
+    // occurrence of the same auxdata. That occurrence gets the next free key.
+    let alreadyMappedMatch: CompilerAuxdataDiff | undefined;
+    let foundUnmappedMatch = false;
     for (let i = 0; i < compilerAuxdataDiffs.length; i++) {
       // Get the current compilerAuxdataDiff
       const compilerAuxdataDiff = compilerAuxdataDiffs[i];
       // The CompiledContractCborAuxdata element keys start from '1'.
       // So key is effectively i + 1
       const auxdataKey = i + 1;
-
-      // If we already mapped this compilerAuxdataDiff, skip
-      if (resultAuxdatas[auxdataKey] !== undefined) continue;
 
       // If in position `pos` of the originalBytecode we find the `compilerAuxdataDiff.real` value
       if (
@@ -165,16 +171,34 @@ export function findAuxdataPositions(
           pos,
         )
       ) {
+        if (resultAuxdatas[auxdataKey] !== undefined) {
+          // Keep as candidate for one more occurrence of this auxdata.
+          if (alreadyMappedMatch === undefined) {
+            alreadyMappedMatch = compilerAuxdataDiff;
+          }
+          continue;
+        }
+
         // Store the CompiledContractCborAuxdata element
         resultAuxdatas[auxdataKey] = {
           offset: (pos - compilerAuxdataDiff.diffStart - 2) / 2,
           value: `0x${compilerAuxdataDiff.real}`,
         };
+        foundUnmappedMatch = true;
         // Match the first auxdata for each bytecodeDiffPosition. If there are multiple identical cborAuxdata,
         // without the break it will always match the last one. With first, it will be "mapped" in the `result[resultIndex]`
         // See https://github.com/argotorg/sourcify/issues/1980
         break;
       }
+    }
+
+    // This position holds one more occurrence of an auxdata that is already mapped.
+    if (!foundUnmappedMatch && alreadyMappedMatch !== undefined) {
+      resultAuxdatas[nextExtraAuxdataKey] = {
+        offset: (pos - alreadyMappedMatch.diffStart - 2) / 2,
+        value: `0x${alreadyMappedMatch.real}`,
+      };
+      nextExtraAuxdataKey++;
     }
 
     prevPos = pos;

--- a/packages/lib-sourcify/test/Compilation/auxdataUtils.spec.ts
+++ b/packages/lib-sourcify/test/Compilation/auxdataUtils.spec.ts
@@ -1,0 +1,150 @@
+import { describe, it } from 'mocha';
+import { expect } from 'chai';
+import { findAuxdataPositions } from '../../src/Compilation/auxdataUtils';
+
+// Builds a CBOR auxdata block (ipfs + solc version) with the given 32-byte hash (hex, 64 chars)
+function auxdataBlock(ipfsHash: string) {
+  return `a2646970667358221220${ipfsHash}64736f6c63430008110033`;
+}
+
+describe('auxdataUtils', () => {
+  describe('findAuxdataPositions', () => {
+    const HASH_A = '11'.repeat(32);
+    const HASH_A_EDITED = '22'.repeat(32);
+    const HASH_B = '33'.repeat(32);
+    const HASH_B_EDITED = '44'.repeat(32);
+
+    const AUXDATA_A = auxdataBlock(HASH_A);
+    const AUXDATA_A_EDITED = auxdataBlock(HASH_A_EDITED);
+    const AUXDATA_B = auxdataBlock(HASH_B);
+    const AUXDATA_B_EDITED = auxdataBlock(HASH_B_EDITED);
+
+    const CODE = '60806040525f80fd';
+
+    it('should find a single auxdata position', () => {
+      const original = `0x${CODE}${AUXDATA_A}`;
+      const edited = `0x${CODE}${AUXDATA_A_EDITED}`;
+
+      const result = findAuxdataPositions(
+        original,
+        edited,
+        [AUXDATA_A],
+        [AUXDATA_A_EDITED],
+      );
+
+      expect(result).to.deep.equal({
+        '1': {
+          offset: CODE.length / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+      });
+    });
+
+    it('should find positions of two different auxdatas', () => {
+      const original = `0x${CODE}${AUXDATA_B}${CODE}${AUXDATA_A}`;
+      const edited = `0x${CODE}${AUXDATA_B_EDITED}${CODE}${AUXDATA_A_EDITED}`;
+
+      const result = findAuxdataPositions(
+        original,
+        edited,
+        [AUXDATA_A, AUXDATA_B],
+        [AUXDATA_A_EDITED, AUXDATA_B_EDITED],
+      );
+
+      expect(result).to.deep.equal({
+        '1': {
+          offset: (CODE.length + AUXDATA_B.length + CODE.length) / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+        '2': {
+          offset: CODE.length / 2,
+          value: `0x${AUXDATA_B}`,
+        },
+      });
+    });
+
+    it('should find all occurrences of an auxdata that repeats in the bytecode', () => {
+      // A contract can embed the same child contract's bytecode multiple times
+      // (e.g. a factory embedding a child's creation code in several code paths).
+      // The compiler output lists the child's auxdata only once, but the bytecode
+      // contains it at multiple positions. All of them have to be found, otherwise
+      // the not-found occurrences are never transformed during verification.
+      const original = `0x${CODE}${AUXDATA_B}${CODE}${AUXDATA_B}${CODE}${AUXDATA_B}${CODE}${AUXDATA_A}`;
+      const edited = `0x${CODE}${AUXDATA_B_EDITED}${CODE}${AUXDATA_B_EDITED}${CODE}${AUXDATA_B_EDITED}${CODE}${AUXDATA_A_EDITED}`;
+
+      const result = findAuxdataPositions(
+        original,
+        edited,
+        [AUXDATA_A, AUXDATA_B],
+        [AUXDATA_A_EDITED, AUXDATA_B_EDITED],
+      );
+
+      const unit = (CODE.length + AUXDATA_B.length) / 2;
+      expect(result).to.deep.equal({
+        '1': {
+          offset: 3 * unit + CODE.length / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+        '2': {
+          offset: CODE.length / 2,
+          value: `0x${AUXDATA_B}`,
+        },
+        '3': {
+          offset: unit + CODE.length / 2,
+          value: `0x${AUXDATA_B}`,
+        },
+        '4': {
+          offset: 2 * unit + CODE.length / 2,
+          value: `0x${AUXDATA_B}`,
+        },
+      });
+    });
+
+    it('should map identical auxdatas listed multiple times by the compiler to distinct positions', () => {
+      // Multiple identical auxdata entries from the compiler output
+      // (see https://github.com/argotorg/sourcify/issues/1980)
+      const original = `0x${CODE}${AUXDATA_A}${CODE}${AUXDATA_A}`;
+      const edited = `0x${CODE}${AUXDATA_A_EDITED}${CODE}${AUXDATA_A_EDITED}`;
+
+      const result = findAuxdataPositions(
+        original,
+        edited,
+        [AUXDATA_A, AUXDATA_A],
+        [AUXDATA_A_EDITED, AUXDATA_A_EDITED],
+      );
+
+      expect(result).to.deep.equal({
+        '1': {
+          offset: CODE.length / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+        '2': {
+          offset: (CODE.length + AUXDATA_A.length + CODE.length) / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+      });
+    });
+
+    it('should not record a position where the bytecodes do not differ', () => {
+      // An auxdata-like constant that does not change with edited sources
+      // (e.g. attacker-embedded static bytes) must not be recorded.
+      const original = `0x${CODE}${AUXDATA_A}${CODE}${AUXDATA_A}`;
+      // Only the second occurrence changes with the edited sources
+      const edited = `0x${CODE}${AUXDATA_A}${CODE}${AUXDATA_A_EDITED}`;
+
+      const result = findAuxdataPositions(
+        original,
+        edited,
+        [AUXDATA_A],
+        [AUXDATA_A_EDITED],
+      );
+
+      expect(result).to.deep.equal({
+        '1': {
+          offset: (CODE.length + AUXDATA_A.length + CODE.length) / 2,
+          value: `0x${AUXDATA_A}`,
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Some factory contracts fail verification with `no_match` even though only metadata hashes differ from the on-chain bytecode. This happens when a contract embeds the **same child contract's bytecode multiple times** — for example a factory that embeds a child's creation code in several code paths.

The compiler's `legacyAssembly` lists the child's auxdata **once**, but the bytecode contains it at **multiple positions**. `findAuxdataPositions` mapped each auxdata value from `legacyAssembly` to exactly one position (`if (resultAuxdatas[auxdataKey] !== undefined) continue`). The additional occurrences were never recorded, `extractAuxdataTransformation` left them untouched, and the bytecode comparison failed.

Concrete example: `ZoraCreator1155FactoryImpl` at `0x169d9147dFc9409AfA4E558dF2C9ABeebc020182` on OP Mainnet (solc 0.8.17). The runtime bytecode contains 4 ipfs auxdata blocks (offsets 9377, 10387, 11397, 11514): the factory's own plus the embedded child's auxdata three times. Only 2 positions were found before this change; with it, all 4 are found and the contract verifies as a partial runtime match. The same pattern affects a number of deployments of this factory family across OP Mainnet, Base and Arbitrum.

## Change

`packages/lib-sourcify/src/Compilation/auxdataUtils.ts` — in `findAuxdataPositions`:

- Positions still map 1:1 to the `legacyAssembly` entries first — existing keys and behavior are unchanged, including the handling of multiple identical auxdata entries from #1980.
- When a bytecode diff position hosts an auxdata value that is **already mapped**, it is recorded as an additional occurrence under the next free key (`'3'`, `'4'`, …).
- The security property is preserved: positions are only considered where the edited-source recompilation actually produces a diff, so statically embedded auxdata-like bytes (which do not change when sources are edited) are still not recorded.

`extractAuxdataTransformation` iterates the position entries generically, so the additional occurrences are transformed without further changes.

## Testing

- New unit tests for `findAuxdataPositions` (`test/Compilation/auxdataUtils.spec.ts`): single auxdata, two different auxdatas, **repeated occurrences of one auxdata (regression test — fails without this change)**, multiple identical `legacyAssembly` entries (#1980 case), and no recording at non-diff positions.
- `SolidityCompilation` suite: 14 passing. `Verification` suite: 43 passing.
- End-to-end: the example contract above goes from `no_match` to a partial runtime match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016kwtTmYc4iYJ4cv1JE5vDd)_