### PR TITLE
Drop the obsolete idx_code_code_first_75 index

### DIFF
--- a/.release-todos/2937-drop-idx-code-code-first-75.md
+++ b/.release-todos/2937-drop-idx-code-code-first-75.md
@@ -1,0 +1,5 @@
+## before
+
+- Run `npm run migrate:up` on the staging database (drops `idx_code_code_first_75`; the drop is instant)
+- Run `npm run migrate:up` on the production database (the drop is instant; frees ~1.1 GB)
+- Note: after this migration, a rollback to a pre-4.0.0 server needs `npm run migrate:down` first. The recreation scans the whole `code` table and takes several minutes on production.

--- a/services/database/migrations/20260820120000_drop_idx_code_code_first_75.sql
+++ b/services/database/migrations/20260820120000_drop_idx_code_code_first_75.sql
@@ -1,0 +1,14 @@
+-- migrate:up
+
+-- idx_code_code_first_75 served the similarity query of server versions
+-- before 4.0.0, which prefix-matched on the code table. The server now
+-- reads compiled_contracts_runtime_code_prefixes instead (see
+-- https://github.com/argotorg/sourcify/issues/2891). The index was kept as
+-- rollback insurance and is no longer needed.
+DROP INDEX IF EXISTS idx_code_code_first_75;
+
+-- migrate:down
+
+-- Recreation scans the whole code table; expect several minutes on production.
+CREATE INDEX IF NOT EXISTS idx_code_code_first_75
+  ON code USING btree (substring(code FROM 1 FOR 75));

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,7 +1,7 @@
 \restrict dbmate
 
--- Dumped from database version 16.14 (Ubuntu 16.14-1.pgdg24.04+1)
--- Dumped by pg_dump version 16.14 (Ubuntu 16.14-1.pgdg24.04+1)
+-- Dumped from database version 16.15 (Ubuntu 16.15-1.pgdg24.04+2)
+-- Dumped by pg_dump version 16.15 (Ubuntu 16.15-1.pgdg24.04+2)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1631,13 +1631,6 @@ CREATE INDEX contracts_runtime_code_hash ON public.contracts USING btree (runtim
 
 
 --
--- Name: idx_code_code_first_75; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_code_code_first_75 ON public.code USING btree (SUBSTRING(code FROM 1 FOR 75));
-
-
---
 -- Name: signature_stats_type_idx; Type: INDEX; Schema: public; Owner: -
 --
 
@@ -2256,4 +2249,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260723090000'),
     ('20260724100000'),
     ('20260729090000'),
-    ('20260803100000');
+    ('20260803100000'),
+    ('20260820120000');


### PR DESCRIPTION
## Summary

Follow-up to #2918 (see #2891): drops `idx_code_code_first_75` on the `code` table.

Server 4.0.0 finds similarity candidates through the `compiled_contracts_runtime_code_prefixes` side table. The old prefix index served only the pre-4.0.0 query and was kept as rollback insurance. The new query is now verified on production: worst-case candidate search (prefix shared by ~102k compilations) runs in 75 ms, typical cold lookups in ~156 ms, batch payload fetch in ~94 ms.

The index takes 1.1 GB on production. The drop is instant; the `migrate:down` recreation scans the whole `code` table and takes several minutes.

## Notes

- Apply with the next regular release; no backfill or ordering constraints.
- After this migration, rollback to a pre-4.0.0 server needs the `migrate:down` first (recreates the index).