### PR TITLE
fix(scripts): abort BigQuery session on close/interrupt in delete-sourcify-match

### DIFF
--- a/scripts/delete-sourcify-match.ts
+++ b/scripts/delete-sourcify-match.ts
@@ -251,8 +251,17 @@ class BigQueryClient implements DatabaseClient {
   }
 
   async close(): Promise<void> {
-    // Session cleanup is handled by BigQuery automatically
-    // when the connection/job completes
+    if (!this.sessionId) return;
+    // BigQuery sessions aren't auto-closed; an open one with an uncommitted
+    // transaction locks the table and blocks later deletes. Abort it explicitly
+    // (also rolls back any in-progress transaction).
+    try {
+      await this.query("CALL BQ.ABORT_SESSION()");
+    } catch {
+      // best-effort; the session otherwise expires on its own idle timeout
+    } finally {
+      this.sessionId = null;
+    }
   }
 }
 
@@ -446,6 +455,20 @@ async function deleteVerifiedContracts(
   dbType: DatabaseType,
 ): Promise<DeleteStats> {
   const client = await createDatabaseClient(dbType);
+
+  // Ctrl-C/SIGTERM skip the try/finally below, which would leave the BigQuery
+  // session's transaction open and holding a lock. Roll back / close on signal.
+  const handleSignal = (signal: NodeJS.Signals) => {
+    console.error(
+      `\n⚠️  Received ${signal} — rolling back and closing the session before exit...`,
+    );
+    client
+      .close()
+      .catch(() => undefined)
+      .finally(() => process.exit(130));
+  };
+  process.once("SIGINT", handleSignal);
+  process.once("SIGTERM", handleSignal);
 
   const stats: DeleteStats = {
     verifiedContractsFound: 0,
@@ -797,6 +820,8 @@ async function deleteVerifiedContracts(
     console.error("\n❌ Transaction rolled back due to error\n");
     throw error;
   } finally {
+    process.removeListener("SIGINT", handleSignal);
+    process.removeListener("SIGTERM", handleSignal);
     await client.close();
   }
 }


### PR DESCRIPTION
## Summary

The BigQuery path of `scripts/delete-sourcify-match.ts` had two session bugs that made it fail (and block itself) on any non-trivial run:

- **Session leak.** It opens a BigQuery *session* per invocation, but `close()` was a no-op that relied on auto-cleanup that doesn't happen — sessions persist for ~24h. A batch delete left hundreds of idle sessions behind.
- **Orphaned lock on interrupt.** A run interrupted mid-transaction (Ctrl-C) never reached the `try/finally`, so the session's transaction stayed **open and held a lock** on the target tables. Every later delete then failed with `Transaction is aborted due to concurrent update against table … public_verified_contracts`, naming the same stuck transaction each time.

## Fix

- `close()` now calls `BQ.ABORT_SESSION()` to end the session and roll back any in-progress transaction, instead of relying on non-existent auto-cleanup.
- Register `SIGINT`/`SIGTERM` handlers so an interrupted run rolls back and closes the session before exiting, rather than orphaning a lock-holding transaction.

Postgres behaviour is unchanged (dropping the client already rolls back).

## Context

Surfaced while deleting the 125 wrong-network Wanchain contracts from chain 999 (#2916): interrupted BigQuery runs repeatedly left zombie sessions whose open transactions locked `public_verified_contracts`, blocking all further deletes until each session was manually aborted with `CALL BQ.ABORT_SESSION(...)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)