### PR TITLE
feat: store metadata once per compilation in compiled_contracts_metadata

### DIFF
--- a/.release-todos/2941-compiled-contracts-metadata.md
+++ b/.release-todos/2941-compiled-contracts-metadata.md
@@ -1,0 +1,12 @@
+# Metadata side table (#2941)
+
+## before
+
+- Run `npm run migrate:up` on the staging and production databases (creates the empty `compiled_contracts_metadata` table, instant)
+
+## after
+
+- Run `services/database/schema-updates/backfill-compiled-contracts-metadata.mjs` against production (see "Available upgrade scripts" in `services/database/README.md`)
+- Run the script again with `--verify` and check it reports `missingRows: 0`
+- In the GCP Datastream console, add `compiled_contracts_metadata` to the included objects of the `sourcify-matches` stream (the stream's backfill mode picks up the new table automatically)
+- Only after all of the above, merge and deploy the read-switch PR #2942

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,19 @@ npm run monitor:start
 
 **The authoritative schema is the committed dump at [`services/database/sourcify-database.sql`](services/database/sourcify-database.sql).** Read it to answer schema questions instead of querying a live database. dbmate regenerates it on `npm run migrate:up`, and it must be committed alongside any new migration (see [`services/database/README.md`](services/database/README.md)).
 
+**Never hand-edit `sourcify-database.sql` — always regenerate it with dbmate.** The `validate-database-schema` CI job applies all migrations to a clean postgres, dumps it, and diffs (comment/blank-line-normalized) against the committed file. pg_dump's object ordering is non-obvious (e.g. constraints sort by constraint name, not table name), so hand-edits get the ordering wrong and fail CI. To regenerate, run the migrations against a disposable local database:
+
+```bash
+# throwaway postgres (matches the version the dump was generated with)
+docker run -d --name schema-regen -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -e POSTGRES_DB=test_db -p 127.0.0.1:55432:5432 postgres:16
+
+cd services/database && DATABASE_URL="postgres://postgres:password@127.0.0.1:55432/test_db?sslmode=disable" DBMATE_SCHEMA_FILE=./sourcify-database.sql npm run migrate:up
+
+docker rm -f schema-regen
+```
+
+dbmate shells out to a local `pg_dump`, which must be version 16 (pgdg `postgresql-client-16`): pg_dump 17 emits `SET transaction_timeout` lines that CI's normalizer does not strip, so its dumps fail the diff.
+
 How the tables join:
 
 - `sourcify_matches.verified_contract_id` → `verified_contracts.id` (Sourcify-specific match info: `creation_match`/`runtime_match` quality, `chain_id`, and the contract's `metadata`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,24 +112,14 @@ npm run monitor:start
 
 **The authoritative schema is the committed dump at [`services/database/sourcify-database.sql`](services/database/sourcify-database.sql).** Read it to answer schema questions instead of querying a live database. dbmate regenerates it on `npm run migrate:up`, and it must be committed alongside any new migration (see [`services/database/README.md`](services/database/README.md)).
 
-**Never hand-edit `sourcify-database.sql` — always regenerate it with dbmate.** The `validate-database-schema` CI job applies all migrations to a clean postgres, dumps it, and diffs (comment/blank-line-normalized) against the committed file. pg_dump's object ordering is non-obvious (e.g. constraints sort by constraint name, not table name), so hand-edits get the ordering wrong and fail CI. To regenerate, run the migrations against a disposable local database:
-
-```bash
-# throwaway postgres (matches the version the dump was generated with)
-docker run -d --name schema-regen -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -e POSTGRES_DB=test_db -p 127.0.0.1:55432:5432 postgres:16
-
-cd services/database && DATABASE_URL="postgres://postgres:password@127.0.0.1:55432/test_db?sslmode=disable" DBMATE_SCHEMA_FILE=./sourcify-database.sql npm run migrate:up
-
-docker rm -f schema-regen
-```
-
-dbmate shells out to a local `pg_dump`, which must be version 16 (pgdg `postgresql-client-16`): pg_dump 17 emits `SET transaction_timeout` lines that CI's normalizer does not strip, so its dumps fail the diff.
+**Never hand-edit `sourcify-database.sql` — always regenerate it with dbmate.** The `validate-database-schema` CI job applies all migrations to a clean postgres, dumps it, and diffs (comment/blank-line-normalized) against the committed file; pg_dump's object ordering is non-obvious (e.g. constraints sort by constraint name, not table name), so hand-edits get the ordering wrong and fail CI. The regeneration recipe (throwaway `postgres:15` container + `DBMATE_SCHEMA_FILE`) is in [`services/database/README.md`](services/database/README.md) under "Adding a new migration"; pg_dump must be version 15 to match CI (pgdg `postgresql-client-15`), not 17.
 
 How the tables join:
 
 - `sourcify_matches.verified_contract_id` → `verified_contracts.id` (Sourcify-specific match info: `creation_match`/`runtime_match` quality, `chain_id`, and the contract's `metadata`)
 - `verified_contracts.compilation_id` → `compiled_contracts.id`, and `verified_contracts.deployment_id` → `contract_deployments.id`
 - `compiled_contracts_sources` (`compilation_id`, `path`, `source_hash`) is the source set stored for a compilation; join `source_hash` → `sources.source_hash` for the actual content
+- `compiled_contracts_metadata.compilation_id` → `compiled_contracts.id`: one metadata blob per compilation (`sourcify_matches.metadata` is kept only until reads switch over, #2924)
 - `code` holds bytecode, referenced via `creation_code_hash`/`runtime_code_hash` by both `compiled_contracts` (compiled) and `contracts` (onchain); reach the latter through `contract_deployments.contract_id` → `contracts.id`
 
 ### Storage Services

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -98,6 +98,22 @@ Please follow these steps:
 Important: Since the schema dump should be committed, ensure that the connected database does not contain any custom schema changes that are not part of the migrations.
 If you are unsure whether your local database has custom schema changes, run the process against a fresh database.
 
+#### Regenerating `sourcify-database.sql`
+
+Never hand-edit `sourcify-database.sql`; always regenerate it with dbmate. The `validate-database-schema` CI job applies all migrations to a clean PostgreSQL, dumps it, and diffs (comment/blank-line-normalized) against the committed file. pg_dump's object ordering is non-obvious (e.g. constraints sort by constraint name, not table name), so hand-edits get the ordering wrong and fail CI.
+
+To regenerate against a disposable local database, from the repository root:
+
+```bash
+docker run -d --name schema-regen -e POSTGRES_PASSWORD=password -e POSTGRES_USER=postgres -e POSTGRES_DB=test_db -p 127.0.0.1:55432:5432 postgres:15
+
+cd services/database && DATABASE_URL="postgres://postgres:password@127.0.0.1:55432/test_db?sslmode=disable" DBMATE_SCHEMA_FILE=./sourcify-database.sql npm run migrate:up
+
+docker rm -f schema-regen
+```
+
+dbmate shells out to a local `pg_dump`, which should be version 15 to match CI (pgdg `postgresql-client-15`). Do not use pg_dump 17: it emits `SET transaction_timeout` lines that CI's normalizer does not strip, so its dumps fail the diff.
+
 ## Schema upgrade scripts
 
 Some schema changes cannot be completed inside a single dbmate migration; for example, data backfills that touch millions of rows and need to run in small batches outside a long transaction. For these cases we keep one-off Node scripts under [`./schema-updates/`](./schema-updates/) that complement the migrations.
@@ -113,6 +129,7 @@ The scripts are idempotent, resumable and they only touch rows that still need w
 | [`post-v0-to-v1-upgrade.mjs`](./schema-updates/post-v0-to-v1-upgrade.mjs)                                                         | After upgrading to the v1 schema, once the `sources` table is populated.                                                                                                  | Backfills `sources.source_hash_keccak` with the keccak256 hash of each source.                                                                                                |
 | [`post-v2.12-to-v2.13-upgrade.mjs`](./schema-updates/post-v2.12-to-v2.13-upgrade.mjs)                                             | After applying the v2.13 migration that adds the nullable `sourcify_matches.chain_id` column, and before applying the follow-up migration that promotes it to `NOT NULL`. | Backfills `sourcify_matches.chain_id` from `contract_deployments.chain_id` in batches.                                                                                        |
 | [`backfill-compiled-contracts-runtime-code-prefixes.mjs`](./schema-updates/backfill-compiled-contracts-runtime-code-prefixes.mjs) | After applying the migration that adds the `compiled_contracts_runtime_code_prefixes` table, and before deploying server version 3.18.0.                                  | Backfills `compiled_contracts_runtime_code_prefixes` (first 75 bytes of each compilation's runtime code) for compilations that existed before the migration's insert trigger. |
+| [`backfill-compiled-contracts-metadata.mjs`](./schema-updates/backfill-compiled-contracts-metadata.mjs)                           | After applying the migration that adds `compiled_contracts_metadata`, on a server that already dual-writes to it. Run `--verify` before switching reads to the table.     | Backfills `compiled_contracts_metadata` from `sourcify_matches.metadata`, one row per compilation (first current match by `verified_contracts.id`).                           |
 
 Run a script with:
 

--- a/services/database/migrations/20260826100000_add_compiled_contracts_metadata.sql
+++ b/services/database/migrations/20260826100000_add_compiled_contracts_metadata.sql
@@ -1,0 +1,41 @@
+-- migrate:up
+
+-- Compiler metadata describes a compilation, not a deployment, yet it is
+-- stored once per verified contract in sourcify_matches.metadata. With one
+-- compilation deployed at thousands of addresses this duplicates identical
+-- blobs 8.5x on average (~139 GB of a 182 GB table).
+-- See: https://github.com/argotorg/sourcify/issues/2924
+--
+-- This table holds one metadata blob per compilation instead. It is a
+-- Sourcify-specific side table (same pattern as sourcify_matches and
+-- compiled_contracts_runtime_code_prefixes): compiled_contracts belongs to the
+-- Verifier Alliance schema and is left untouched structurally.
+--
+-- Where a compilation has several metadata variants (possible with
+-- settings.metadata.bytecodeHash: "none", where differing comments or paths
+-- still produce identical bytecode), the first submitter's variant wins --
+-- consistent with how sources are deduplicated for a shared compilation.
+--
+-- The column is json, NOT jsonb, deliberately: json preserves the exact
+-- stored text, so the blob keeps hashing to the metadata hash embedded in the
+-- onchain bytecode. jsonb re-serializes with its own key order and would break
+-- that property permanently.
+--
+-- This migration only creates the table:
+--   - New compilations are covered by the server, which writes metadata here
+--     at verification time (dual-writing to sourcify_matches.metadata for now).
+--   - Existing rows are backfilled out-of-band by the (idempotent, resumable)
+--     script services/database/schema-updates/backfill-compiled-contracts-metadata.mjs.
+--     Backfilling all ~5M compilations in here would detoast and rewrite tens
+--     of GB inside one transaction, which is not acceptable on production.
+--   - Reads stay on sourcify_matches.metadata until the backfill has completed;
+--     switching them over and dropping the old column are follow-up steps.
+CREATE TABLE compiled_contracts_metadata (
+    compilation_id uuid NOT NULL PRIMARY KEY
+        REFERENCES compiled_contracts(id) ON DELETE CASCADE,
+    metadata json NOT NULL
+);
+
+-- migrate:down
+
+DROP TABLE IF EXISTS compiled_contracts_metadata;

--- a/services/database/migrations/20260826100000_add_compiled_contracts_metadata.sql
+++ b/services/database/migrations/20260826100000_add_compiled_contracts_metadata.sql
@@ -1,35 +1,14 @@
 -- migrate:up
 
--- Compiler metadata describes a compilation, not a deployment, yet it is
--- stored once per verified contract in sourcify_matches.metadata. With one
--- compilation deployed at thousands of addresses this duplicates identical
--- blobs 8.5x on average (~139 GB of a 182 GB table).
--- See: https://github.com/argotorg/sourcify/issues/2924
+-- One metadata blob per compilation instead of one per verified contract
+-- (~139 GB of duplicates in sourcify_matches.metadata, see issue #2924).
+-- Sourcify-specific side table; the Verifier Alliance compiled_contracts
+-- table stays untouched. json, not jsonb: preserves the exact text so the
+-- blob keeps hashing to the metadata hash embedded in the onchain bytecode.
 --
--- This table holds one metadata blob per compilation instead. It is a
--- Sourcify-specific side table (same pattern as sourcify_matches and
--- compiled_contracts_runtime_code_prefixes): compiled_contracts belongs to the
--- Verifier Alliance schema and is left untouched structurally.
---
--- Where a compilation has several metadata variants (possible with
--- settings.metadata.bytecodeHash: "none", where differing comments or paths
--- still produce identical bytecode), the first submitter's variant wins --
--- consistent with how sources are deduplicated for a shared compilation.
---
--- The column is json, NOT jsonb, deliberately: json preserves the exact
--- stored text, so the blob keeps hashing to the metadata hash embedded in the
--- onchain bytecode. jsonb re-serializes with its own key order and would break
--- that property permanently.
---
--- This migration only creates the table:
---   - New compilations are covered by the server, which writes metadata here
---     at verification time (dual-writing to sourcify_matches.metadata for now).
---   - Existing rows are backfilled out-of-band by the (idempotent, resumable)
---     script services/database/schema-updates/backfill-compiled-contracts-metadata.mjs.
---     Backfilling all ~5M compilations in here would detoast and rewrite tens
---     of GB inside one transaction, which is not acceptable on production.
---   - Reads stay on sourcify_matches.metadata until the backfill has completed;
---     switching them over and dropping the old column are follow-up steps.
+-- Table only: the server dual-writes new verifications; existing rows are
+-- backfilled by schema-updates/backfill-compiled-contracts-metadata.mjs.
+-- Reads stay on sourcify_matches.metadata until the backfill completes.
 CREATE TABLE compiled_contracts_metadata (
     compilation_id uuid NOT NULL PRIMARY KEY
         REFERENCES compiled_contracts(id) ON DELETE CASCADE,

--- a/services/database/schema-updates/backfill-compiled-contracts-metadata.mjs
+++ b/services/database/schema-updates/backfill-compiled-contracts-metadata.mjs
@@ -91,6 +91,14 @@ const firstMatchMetadataLateral = `
     LIMIT 1
   ) first_match`;
 
+// Makes re-runs skip already-filled compilations. Filters batch_metadata, not
+// batch, so the cursor still advances through completed ranges.
+const skipExistingRows = `
+  WHERE NOT EXISTS (
+    SELECT 1 FROM ${schema}.compiled_contracts_metadata ccm
+    WHERE ccm.compilation_id = batch.id
+  )`;
+
 program
   .description(
     "Backfill compiled_contracts_metadata from sourcify_matches.metadata.\n" +
@@ -134,7 +142,7 @@ program
     // the end of a normal run. Use it before switching reads over to the side
     // table.
     "--verify",
-    "Only compare the number of compilations expecting metadata against the side table, then exit.",
+    "Only count compilations still missing their side table row, then exit.",
     false,
   )
   .action(async (options) => {
@@ -148,20 +156,19 @@ program
 
     if (options.verify) {
       logger.info("Verifying compiled_contracts_metadata completeness");
+      // Counts the gap directly: comparing totals instead could hide gaps,
+      // because the side table also keeps rows for compilations that no
+      // current match points to anymore.
       const result = await activePool.query(
-        `SELECT
-           (SELECT count(DISTINCT vc.compilation_id)
-            FROM ${schema}.verified_contracts vc
-            JOIN ${schema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
-            WHERE sm.metadata IS NOT NULL) AS expected_rows,
-           (SELECT count(*) FROM ${schema}.compiled_contracts_metadata) AS actual_rows`,
+        `SELECT count(DISTINCT vc.compilation_id) AS missing_rows
+         FROM ${schema}.verified_contracts vc
+         JOIN ${schema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
+         WHERE sm.metadata IS NOT NULL
+           AND NOT EXISTS (SELECT 1 FROM ${schema}.compiled_contracts_metadata ccm
+                           WHERE ccm.compilation_id = vc.compilation_id)`,
       );
-      const expectedRows = parseInt(result.rows[0].expected_rows, 10);
-      const actualRows = parseInt(result.rows[0].actual_rows, 10);
       logger.info("Verification finished", {
-        expectedRows,
-        actualRows,
-        missingRows: expectedRows - actualRows,
+        missingRows: parseInt(result.rows[0].missing_rows, 10),
       });
       await closePool();
       return;
@@ -206,6 +213,7 @@ program
              SELECT batch.id AS compilation_id
              FROM batch
              ${firstMatchMetadataLateral}
+             ${skipExistingRows}
            )
            SELECT (SELECT count(*) FROM batch) AS batch_rows,
                   (SELECT count(*) FROM batch_metadata) AS insertable_rows,
@@ -231,6 +239,7 @@ program
              SELECT batch.id AS compilation_id, first_match.metadata
              FROM batch
              ${firstMatchMetadataLateral}
+             ${skipExistingRows}
            ),
            inserted AS (
              INSERT INTO ${schema}.compiled_contracts_metadata (compilation_id, metadata)
@@ -307,4 +316,8 @@ program
     await closePool();
   });
 
-program.parse();
+program.parseAsync().catch(async (err) => {
+  logger.error("Fatal error", { error: err.message, stack: err.stack });
+  await closePool();
+  process.exit(1);
+});

--- a/services/database/schema-updates/backfill-compiled-contracts-metadata.mjs
+++ b/services/database/schema-updates/backfill-compiled-contracts-metadata.mjs
@@ -1,0 +1,310 @@
+/**
+ * Backfills compiled_contracts_metadata from sourcify_matches.metadata.
+ *
+ * Required after applying the migration that adds the metadata side table
+ * (20260826100000_add_compiled_contracts_metadata.sql): the server only writes
+ * metadata for verifications stored after the migration, so compilations
+ * verified before it are filled out-of-band by this script. Until it has
+ * finished, reads keep using sourcify_matches.metadata, so nothing is missing
+ * in the meantime.
+ *
+ * For each compilation the metadata of its earliest current sourcify_match
+ * (lowest verified_contracts.id) is stored -- the first submitter wins,
+ * consistent with how sources are deduplicated for a shared compilation.
+ * Compilations without any match, or whose matches all have NULL metadata,
+ * get no row.
+ *
+ * The script is idempotent and resumable: inserts use ON CONFLICT DO NOTHING
+ * and the table is walked in primary-key order with a keyset cursor
+ * (compiled_contracts.id is a uuid, so ranges are cursor-based rather than
+ * numeric). Safe to Ctrl+C and re-run. Rows written concurrently by the live
+ * server are left untouched.
+ *
+ * See: https://github.com/argotorg/sourcify/issues/2924
+ *
+ * Environment Variables Required:
+ *   - POSTGRES_HOST
+ *   - POSTGRES_PORT
+ *   - POSTGRES_DB
+ *   - POSTGRES_USER
+ *   - POSTGRES_PASSWORD
+ *
+ * Example:
+ *   node backfill-compiled-contracts-metadata.mjs --batch-size=5000 --sleep-ms=50
+ */
+
+import { program } from "commander";
+import dotenv from "dotenv";
+import pg from "pg";
+import { logger } from "./logger.js";
+
+const { Pool } = pg;
+dotenv.config({ path: "../.env" });
+
+const schema = process.env.POSTGRES_SCHEMA || "public";
+
+const UUID_ZERO = "00000000-0000-0000-0000-000000000000";
+
+let activePool = null;
+
+const closePool = async () => {
+  if (activePool) {
+    try {
+      await activePool.end();
+      logger.info("Successfully closed database pool");
+    } catch (err) {
+      logger.error("Error closing pool", { error: err.message });
+    }
+    activePool = null;
+  }
+};
+
+process.on("SIGINT", async () => {
+  logger.info("Received SIGINT (Ctrl+C). Cleaning up...");
+  await closePool();
+  process.exit(0);
+});
+
+process.on("SIGTERM", async () => {
+  logger.info("Received SIGTERM. Cleaning up...");
+  await closePool();
+  process.exit(0);
+});
+
+const parsePositiveInt = (value, fallback) => {
+  const parsed = parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+};
+
+// The LATERAL picks each compilation's first-submitted metadata; both hops
+// (verified_contracts by compilation_id, sourcify_matches by
+// verified_contract_id) are index-driven. Ordering by verified_contracts.id
+// makes the picked variant deterministic across re-runs.
+const firstMatchMetadataLateral = `
+  CROSS JOIN LATERAL (
+    SELECT sm.metadata
+    FROM ${schema}.verified_contracts vc
+    JOIN ${schema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
+    WHERE vc.compilation_id = batch.id
+      AND sm.metadata IS NOT NULL
+    ORDER BY vc.id
+    LIMIT 1
+  ) first_match`;
+
+program
+  .description(
+    "Backfill compiled_contracts_metadata from sourcify_matches.metadata.\n" +
+      "Idempotent and resumable. Run after applying the metadata side table migration\n" +
+      "on a server version that already dual-writes to compiled_contracts_metadata.\n\n" +
+      "Logging level can be configured via NODE_LOG_LEVEL (default: 'info').",
+  )
+  .option(
+    "-b, --batch-size <number>",
+    "Number of compilations to process per batch",
+    (v) => parsePositiveInt(v, 5000),
+    5000,
+  )
+  .option(
+    // Throttle: without a pause the backfill is one continuous full-speed
+    // workload competing with live traffic for I/O and WAL bandwidth and
+    // building replication lag. The gaps let other work catch up, at the cost
+    // of some total runtime. Set to 0 in an idle window, raise it if the
+    // database is under pressure while the script runs.
+    "-s, --sleep-ms <number>",
+    "Milliseconds to sleep between batches",
+    (v) => {
+      const n = parseInt(v, 10);
+      return Number.isFinite(n) && n >= 0 ? n : 50;
+    },
+    50,
+  )
+  .option(
+    "--start-id <uuid>",
+    "Resume from this compiled_contracts.id (exclusive). Defaults to the zero uuid.",
+    UUID_ZERO,
+  )
+  .option(
+    "--dry-run",
+    "Report what would be inserted without writing anything.",
+    false,
+  )
+  .option(
+    // The completeness check joins all sourcify_matches once (index-driven, no
+    // metadata detoasting), so it is much heavier than the count reported at
+    // the end of a normal run. Use it before switching reads over to the side
+    // table.
+    "--verify",
+    "Only compare the number of compilations expecting metadata against the side table, then exit.",
+    false,
+  )
+  .action(async (options) => {
+    activePool = new Pool({
+      host: process.env.POSTGRES_HOST,
+      port: process.env.POSTGRES_PORT,
+      database: process.env.POSTGRES_DB,
+      user: process.env.POSTGRES_USER,
+      password: process.env.POSTGRES_PASSWORD,
+    });
+
+    if (options.verify) {
+      logger.info("Verifying compiled_contracts_metadata completeness");
+      const result = await activePool.query(
+        `SELECT
+           (SELECT count(DISTINCT vc.compilation_id)
+            FROM ${schema}.verified_contracts vc
+            JOIN ${schema}.sourcify_matches sm ON sm.verified_contract_id = vc.id
+            WHERE sm.metadata IS NOT NULL) AS expected_rows,
+           (SELECT count(*) FROM ${schema}.compiled_contracts_metadata) AS actual_rows`,
+      );
+      const expectedRows = parseInt(result.rows[0].expected_rows, 10);
+      const actualRows = parseInt(result.rows[0].actual_rows, 10);
+      logger.info("Verification finished", {
+        expectedRows,
+        actualRows,
+        missingRows: expectedRows - actualRows,
+      });
+      await closePool();
+      return;
+    }
+
+    logger.info("Starting backfill of compiled_contracts_metadata", {
+      batchSize: options.batchSize,
+      sleepMs: options.sleepMs,
+      startId: options.startId,
+      dryRun: options.dryRun,
+    });
+
+    const estimate = await activePool.query(
+      `SELECT GREATEST(reltuples, 0)::bigint AS estimated_rows
+       FROM pg_class
+       WHERE oid = '${schema}.compiled_contracts'::regclass`,
+    );
+    const estimatedRows = parseInt(estimate.rows[0].estimated_rows, 10);
+    logger.info("Estimated compiled_contracts rows", { estimatedRows });
+
+    let cursor = options.startId;
+    let totalProcessed = 0;
+    let totalInserted = 0;
+    const startTime = Date.now();
+
+    for (;;) {
+      const batchStart = Date.now();
+      let batchRows;
+      let insertedRows;
+      let lastId;
+
+      if (options.dryRun) {
+        const result = await activePool.query(
+          `WITH batch AS (
+             SELECT compiled_contracts.id
+             FROM ${schema}.compiled_contracts
+             WHERE compiled_contracts.id > $1::uuid
+             ORDER BY compiled_contracts.id
+             LIMIT $2
+           ),
+           batch_metadata AS (
+             SELECT batch.id AS compilation_id
+             FROM batch
+             ${firstMatchMetadataLateral}
+           )
+           SELECT (SELECT count(*) FROM batch) AS batch_rows,
+                  (SELECT count(*) FROM batch_metadata) AS insertable_rows,
+                  (SELECT id FROM batch ORDER BY id DESC LIMIT 1) AS last_id`,
+          [cursor, options.batchSize],
+        );
+        batchRows = parseInt(result.rows[0].batch_rows, 10);
+        insertedRows = 0;
+        lastId = result.rows[0].last_id;
+        logger.debug("[dry-run] insertable rows in batch", {
+          insertableRows: parseInt(result.rows[0].insertable_rows, 10),
+        });
+      } else {
+        const result = await activePool.query(
+          `WITH batch AS (
+             SELECT compiled_contracts.id
+             FROM ${schema}.compiled_contracts
+             WHERE compiled_contracts.id > $1::uuid
+             ORDER BY compiled_contracts.id
+             LIMIT $2
+           ),
+           batch_metadata AS (
+             SELECT batch.id AS compilation_id, first_match.metadata
+             FROM batch
+             ${firstMatchMetadataLateral}
+           ),
+           inserted AS (
+             INSERT INTO ${schema}.compiled_contracts_metadata (compilation_id, metadata)
+             SELECT compilation_id, metadata FROM batch_metadata
+             ON CONFLICT (compilation_id) DO NOTHING
+             RETURNING 1
+           )
+           SELECT (SELECT count(*) FROM batch) AS batch_rows,
+                  (SELECT count(*) FROM inserted) AS inserted_rows,
+                  (SELECT id FROM batch ORDER BY id DESC LIMIT 1) AS last_id`,
+          [cursor, options.batchSize],
+        );
+        batchRows = parseInt(result.rows[0].batch_rows, 10);
+        insertedRows = parseInt(result.rows[0].inserted_rows, 10);
+        lastId = result.rows[0].last_id;
+      }
+
+      if (batchRows === 0) {
+        break;
+      }
+
+      cursor = lastId;
+      totalProcessed += batchRows;
+      totalInserted += insertedRows;
+
+      const elapsedSec = (Date.now() - startTime) / 1000;
+      const rowsPerSec = elapsedSec > 0 ? totalProcessed / elapsedSec : 0;
+      const remaining = Math.max(0, estimatedRows - totalProcessed);
+      const etaSec = rowsPerSec > 0 ? remaining / rowsPerSec : 0;
+
+      logger.info(options.dryRun ? "[dry-run] batch" : "Batch complete", {
+        lastId,
+        batchRows,
+        insertedRows,
+        totalProcessed,
+        totalInserted,
+        batchMs: Date.now() - batchStart,
+        etaMinutes: Math.round(etaSec / 60),
+      });
+
+      if (options.sleepMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, options.sleepMs));
+      }
+    }
+
+    logger.info("Backfill finished", {
+      totalProcessed,
+      totalInserted,
+      elapsedMinutes: Math.round((Date.now() - startTime) / 60000),
+    });
+
+    if (!options.dryRun) {
+      const counts = await activePool.query(
+        `SELECT count(*) AS metadata_rows
+         FROM ${schema}.compiled_contracts_metadata`,
+      );
+      logger.info("Metadata table row count", {
+        metadataRows: counts.rows[0].metadata_rows,
+      });
+
+      // A freshly filled table has no statistics; without them the planner
+      // falls back to default estimates for the primary key joins.
+      try {
+        await activePool.query(`ANALYZE ${schema}.compiled_contracts_metadata`);
+        logger.info("ANALYZE completed on compiled_contracts_metadata");
+      } catch (err) {
+        logger.warn(
+          "ANALYZE failed (needs table owner); run it manually before switching reads to the new table",
+          { error: err.message },
+        );
+      }
+    }
+
+    await closePool();
+  });
+
+program.parse();

--- a/services/database/sourcify-database.sql
+++ b/services/database/sourcify-database.sql
@@ -1,7 +1,7 @@
 \restrict dbmate
 
--- Dumped from database version 16.15 (Ubuntu 16.15-1.pgdg24.04+2)
--- Dumped by pg_dump version 16.15 (Ubuntu 16.15-1.pgdg24.04+2)
+-- Dumped from database version 15.19 (Debian 15.19-1.pgdg13+2)
+-- Dumped by pg_dump version 15.19 (Debian 15.19-1.pgdg13+2)
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1029,6 +1029,16 @@ CREATE TABLE public.compiled_contracts (
 
 
 --
+-- Name: compiled_contracts_metadata; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.compiled_contracts_metadata (
+    compilation_id uuid NOT NULL,
+    metadata json NOT NULL
+);
+
+
+--
 -- Name: compiled_contracts_runtime_code_prefixes; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -1328,6 +1338,14 @@ ALTER TABLE ONLY public.verified_contracts ALTER COLUMN id SET DEFAULT nextval('
 
 ALTER TABLE ONLY public.code
     ADD CONSTRAINT code_pkey PRIMARY KEY (code_hash);
+
+
+--
+-- Name: compiled_contracts_metadata compiled_contracts_metadata_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compiled_contracts_metadata
+    ADD CONSTRAINT compiled_contracts_metadata_pkey PRIMARY KEY (compilation_id);
 
 
 --
@@ -2101,6 +2119,14 @@ ALTER TABLE ONLY public.compiled_contracts
 
 
 --
+-- Name: compiled_contracts_metadata compiled_contracts_metadata_compilation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.compiled_contracts_metadata
+    ADD CONSTRAINT compiled_contracts_metadata_compilation_id_fkey FOREIGN KEY (compilation_id) REFERENCES public.compiled_contracts(id) ON DELETE CASCADE;
+
+
+--
 -- Name: compiled_contracts compiled_contracts_runtime_code_hash_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -2250,4 +2276,5 @@ INSERT INTO public.schema_migrations (version) VALUES
     ('20260724100000'),
     ('20260729090000'),
     ('20260803100000'),
-    ('20260820120000');
+    ('20260820120000'),
+    ('20260826100000');

--- a/services/server/src/server/apiPrivate/customReplaceMethods.ts
+++ b/services/server/src/server/apiPrivate/customReplaceMethods.ts
@@ -173,10 +173,23 @@ export const replaceMetadata: CustomReplaceMethod = async (
   const matchId = existingSourcifyMatch.rows[0].id;
 
   await sourcifyDatabaseService.database.pool.query(
-    `UPDATE sourcify_matches 
-       SET 
+    `UPDATE sourcify_matches
+       SET
          metadata = $2
        WHERE id = $1`,
+    [matchId, verification.compilation.metadata],
+  );
+
+  // Also repair the side table; DO UPDATE because the dual-write inserts are
+  // DO NOTHING (#2924). Affects every contract sharing the compilation.
+  await sourcifyDatabaseService.database.pool.query(
+    `INSERT INTO compiled_contracts_metadata (compilation_id, metadata)
+       SELECT vc.compilation_id, $2::json
+       FROM sourcify_matches sm
+       JOIN verified_contracts vc ON vc.id = sm.verified_contract_id
+       WHERE sm.id = $1
+     ON CONFLICT ON CONSTRAINT compiled_contracts_metadata_pkey
+       DO UPDATE SET metadata = EXCLUDED.metadata`,
     [matchId, verification.compilation.metadata],
   );
 };

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -51,7 +51,10 @@ export default abstract class AbstractDatabaseService {
   async insertNewVerifiedContract(
     databaseColumns: DatabaseUtil.DatabaseColumns,
     client: PoolClient,
-  ): Promise<Tables.VerifiedContract["id"]> {
+  ): Promise<{
+    verifiedContractId: Tables.VerifiedContract["id"];
+    compilationId: Tables.CompiledContract["id"];
+  }> {
     try {
       let recompiledCreationCodeInsertResult:
         | QueryResult<Pick<DatabaseUtil.Tables.Code, "bytecode_hash">>
@@ -126,7 +129,10 @@ export default abstract class AbstractDatabaseService {
           compilation_id: compiledContractId,
           deployment_id: contractDeploymentInsertResult.rows[0].id,
         });
-      return verifiedContractInsertResult.rows[0].id;
+      return {
+        verifiedContractId: verifiedContractInsertResult.rows[0].id,
+        compilationId: compiledContractId,
+      };
     } catch (e) {
       throw new Error(
         `cannot insert verified_contract address=0x${databaseColumns.contractDeployment.address.toString("hex")} chainId=${databaseColumns.contractDeployment.chain_id}\n${e}`,
@@ -137,7 +143,10 @@ export default abstract class AbstractDatabaseService {
   async updateExistingVerifiedContract(
     databaseColumns: DatabaseUtil.DatabaseColumns,
     client: PoolClient,
-  ): Promise<Tables.VerifiedContract["id"]> {
+  ): Promise<{
+    verifiedContractId: Tables.VerifiedContract["id"];
+    compilationId: Tables.CompiledContract["id"];
+  }> {
     // runtime bytecodes must exist
     if (databaseColumns.recompiledRuntimeCode.bytecode === undefined) {
       throw new Error("Missing normalized runtime bytecode");
@@ -220,11 +229,14 @@ export default abstract class AbstractDatabaseService {
       const verifiedContractInsertResult =
         await this.database.insertVerifiedContract(client, {
           ...databaseColumns.verifiedContract,
-          compilation_id: compiledContractsInsertResult.rows[0].id,
+          compilation_id: compiledContractId,
           deployment_id: contractDeploymentId,
         });
 
-      return verifiedContractInsertResult.rows[0].id;
+      return {
+        verifiedContractId: verifiedContractInsertResult.rows[0].id,
+        compilationId: compiledContractId,
+      };
     } catch (e) {
       if (e instanceof ConflictError) {
         throw e;
@@ -241,6 +253,7 @@ export default abstract class AbstractDatabaseService {
   ): Promise<{
     type: "update" | "insert";
     verifiedContractId: Tables.VerifiedContract["id"];
+    compilationId: Tables.CompiledContract["id"];
     oldVerifiedContractId?: Tables.VerifiedContract["id"];
   }> {
     this.validateVerificationBeforeStoring(verification);
@@ -259,20 +272,20 @@ export default abstract class AbstractDatabaseService {
       );
 
     if (existingVerifiedContractResult.rowCount === 0) {
+      const { verifiedContractId, compilationId } =
+        await this.insertNewVerifiedContract(databaseColumns, poolClient);
       return {
         type: "insert",
-        verifiedContractId: await this.insertNewVerifiedContract(
-          databaseColumns,
-          poolClient,
-        ),
+        verifiedContractId,
+        compilationId,
       };
     } else {
+      const { verifiedContractId, compilationId } =
+        await this.updateExistingVerifiedContract(databaseColumns, poolClient);
       return {
         type: "update",
-        verifiedContractId: await this.updateExistingVerifiedContract(
-          databaseColumns,
-          poolClient,
-        ),
+        verifiedContractId,
+        compilationId,
         oldVerifiedContractId: existingVerifiedContractResult.rows[0].id,
       };
     }

--- a/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/AbstractDatabaseService.ts
@@ -54,6 +54,7 @@ export default abstract class AbstractDatabaseService {
   ): Promise<{
     verifiedContractId: Tables.VerifiedContract["id"];
     compilationId: Tables.CompiledContract["id"];
+    isNewCompilation: boolean;
   }> {
     try {
       let recompiledCreationCodeInsertResult:
@@ -132,6 +133,7 @@ export default abstract class AbstractDatabaseService {
       return {
         verifiedContractId: verifiedContractInsertResult.rows[0].id,
         compilationId: compiledContractId,
+        isNewCompilation,
       };
     } catch (e) {
       throw new Error(
@@ -146,6 +148,7 @@ export default abstract class AbstractDatabaseService {
   ): Promise<{
     verifiedContractId: Tables.VerifiedContract["id"];
     compilationId: Tables.CompiledContract["id"];
+    isNewCompilation: boolean;
   }> {
     // runtime bytecodes must exist
     if (databaseColumns.recompiledRuntimeCode.bytecode === undefined) {
@@ -236,6 +239,7 @@ export default abstract class AbstractDatabaseService {
       return {
         verifiedContractId: verifiedContractInsertResult.rows[0].id,
         compilationId: compiledContractId,
+        isNewCompilation,
       };
     } catch (e) {
       if (e instanceof ConflictError) {
@@ -254,6 +258,7 @@ export default abstract class AbstractDatabaseService {
     type: "update" | "insert";
     verifiedContractId: Tables.VerifiedContract["id"];
     compilationId: Tables.CompiledContract["id"];
+    isNewCompilation: boolean;
     oldVerifiedContractId?: Tables.VerifiedContract["id"];
   }> {
     this.validateVerificationBeforeStoring(verification);
@@ -272,20 +277,22 @@ export default abstract class AbstractDatabaseService {
       );
 
     if (existingVerifiedContractResult.rowCount === 0) {
-      const { verifiedContractId, compilationId } =
+      const { verifiedContractId, compilationId, isNewCompilation } =
         await this.insertNewVerifiedContract(databaseColumns, poolClient);
       return {
         type: "insert",
         verifiedContractId,
         compilationId,
+        isNewCompilation,
       };
     } else {
-      const { verifiedContractId, compilationId } =
+      const { verifiedContractId, compilationId, isNewCompilation } =
         await this.updateExistingVerifiedContract(databaseColumns, poolClient);
       return {
         type: "update",
         verifiedContractId,
         compilationId,
+        isNewCompilation,
         oldVerifiedContractId: existingVerifiedContractResult.rows[0].id,
       };
     }

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -595,11 +595,12 @@ export class SourcifyDatabaseService
 
       // Temporary dual-write: reads stay on sourcify_matches.metadata until
       // the backfill completes, then the column gets dropped (issue #2924).
-      // Existing compilations already have their row (dual-write or backfill).
-      if (isNewCompilation) {
+      // Existing compilations already have their row; Vyper has no metadata.
+      const metadata = verification.compilation.metadata;
+      if (isNewCompilation && metadata) {
         await this.database.insertCompiledContractMetadata(poolClient, {
           compilation_id: compilationId,
-          metadata: verification.compilation.metadata,
+          metadata,
         });
       }
 

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -534,7 +534,7 @@ export class SourcifyDatabaseService
     },
   ): Promise<{ verifiedContractId: Tables.VerifiedContract["id"] }> {
     try {
-      const { type, verifiedContractId, oldVerifiedContractId } =
+      const { type, verifiedContractId, compilationId, oldVerifiedContractId } =
         await super.insertOrUpdateVerification(verification, poolClient);
 
       if (type === "insert") {
@@ -587,6 +587,16 @@ export class SourcifyDatabaseService
           "insertOrUpdateVerifiedContract returned a type that doesn't exist",
         );
       }
+
+      // Also store the metadata once per compilation. This dual-write is
+      // temporary: reads keep using sourcify_matches.metadata until all
+      // pre-existing compilations are backfilled into
+      // compiled_contracts_metadata, after which the sourcify_matches.metadata
+      // column can be dropped. See https://github.com/argotorg/sourcify/issues/2924
+      await this.database.insertCompiledContractMetadata(poolClient, {
+        compilation_id: compilationId,
+        metadata: verification.compilation.metadata as any,
+      });
 
       // Update the verification job to be successful
       if (jobData) {

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -534,8 +534,13 @@ export class SourcifyDatabaseService
     },
   ): Promise<{ verifiedContractId: Tables.VerifiedContract["id"] }> {
     try {
-      const { type, verifiedContractId, compilationId, oldVerifiedContractId } =
-        await super.insertOrUpdateVerification(verification, poolClient);
+      const {
+        type,
+        verifiedContractId,
+        compilationId,
+        isNewCompilation,
+        oldVerifiedContractId,
+      } = await super.insertOrUpdateVerification(verification, poolClient);
 
       if (type === "insert") {
         if (!verifiedContractId) {
@@ -589,11 +594,14 @@ export class SourcifyDatabaseService
       }
 
       // Temporary dual-write: reads stay on sourcify_matches.metadata until
-      // the backfill completes, then the column gets dropped (issue #2924)
-      await this.database.insertCompiledContractMetadata(poolClient, {
-        compilation_id: compilationId,
-        metadata: verification.compilation.metadata as any,
-      });
+      // the backfill completes, then the column gets dropped (issue #2924).
+      // Existing compilations already have their row (dual-write or backfill).
+      if (isNewCompilation) {
+        await this.database.insertCompiledContractMetadata(poolClient, {
+          compilation_id: compilationId,
+          metadata: verification.compilation.metadata,
+        });
+      }
 
       // Update the verification job to be successful
       if (jobData) {

--- a/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
+++ b/services/server/src/server/services/storageServices/SourcifyDatabaseService.ts
@@ -588,11 +588,8 @@ export class SourcifyDatabaseService
         );
       }
 
-      // Also store the metadata once per compilation. This dual-write is
-      // temporary: reads keep using sourcify_matches.metadata until all
-      // pre-existing compilations are backfilled into
-      // compiled_contracts_metadata, after which the sourcify_matches.metadata
-      // column can be dropped. See https://github.com/argotorg/sourcify/issues/2924
+      // Temporary dual-write: reads stay on sourcify_matches.metadata until
+      // the backfill completes, then the column gets dropped (issue #2924)
       await this.database.insertCompiledContractMetadata(poolClient, {
         compilation_id: compilationId,
         metadata: verification.compilation.metadata as any,

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -800,10 +800,6 @@ ${
     poolClient: PoolClient,
     { compilation_id, metadata }: Tables.CompiledContractMetadata,
   ) {
-    if (!metadata) {
-      return;
-    }
-
     // ON CONFLICT DO NOTHING keeps the first submitter's metadata when a
     // compilation is shared by several verified contracts, consistent with how
     // compiled_contracts_sources are deduplicated

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -796,6 +796,28 @@ ${
     );
   }
 
+  async insertCompiledContractMetadata(
+    poolClient: PoolClient,
+    { compilation_id, metadata }: Tables.CompiledContractMetadata,
+  ) {
+    // Not every compilation has metadata (e.g. Vyper contracts)
+    if (!metadata) {
+      return;
+    }
+
+    // ON CONFLICT DO NOTHING keeps the first submitter's metadata when a
+    // compilation is shared by several verified contracts, consistent with how
+    // compiled_contracts_sources are deduplicated
+    await poolClient.query(
+      `INSERT INTO ${this.schema}.compiled_contracts_metadata (
+        compilation_id,
+        metadata
+      ) VALUES ($1, $2)
+      ON CONFLICT (compilation_id) DO NOTHING`,
+      [compilation_id, metadata],
+    );
+  }
+
   async insertSignatures(
     signatures: Omit<Tables.Signatures, "signature_hash_4">[],
     poolClient?: PoolClient,

--- a/services/server/src/server/services/utils/Database.ts
+++ b/services/server/src/server/services/utils/Database.ts
@@ -800,7 +800,6 @@ ${
     poolClient: PoolClient,
     { compilation_id, metadata }: Tables.CompiledContractMetadata,
   ) {
-    // Not every compilation has metadata (e.g. Vyper contracts)
     if (!metadata) {
       return;
     }
@@ -813,7 +812,7 @@ ${
         compilation_id,
         metadata
       ) VALUES ($1, $2)
-      ON CONFLICT (compilation_id) DO NOTHING`,
+      ON CONFLICT ON CONSTRAINT compiled_contracts_metadata_pkey DO NOTHING`,
       [compilation_id, metadata],
     );
   }

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -157,6 +157,11 @@ export namespace Tables {
     chain_id: string;
   }
 
+  export interface CompiledContractMetadata {
+    compilation_id: string;
+    metadata: Metadata;
+  }
+
   export interface CompilationArtifactsSources {
     [globalName: string]: {
       id: number;

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -159,8 +159,7 @@ export namespace Tables {
 
   export interface CompiledContractMetadata {
     compilation_id: string;
-    // Not every compilation has metadata (e.g. Vyper contracts)
-    metadata?: Metadata;
+    metadata: Metadata;
   }
 
   export interface CompilationArtifactsSources {

--- a/services/server/src/server/services/utils/database-util.ts
+++ b/services/server/src/server/services/utils/database-util.ts
@@ -159,7 +159,8 @@ export namespace Tables {
 
   export interface CompiledContractMetadata {
     compilation_id: string;
-    metadata: Metadata;
+    // Not every compilation has metadata (e.g. Vyper contracts)
+    metadata?: Metadata;
   }
 
   export interface CompilationArtifactsSources {

--- a/services/server/test/helpers/assertions.ts
+++ b/services/server/test/helpers/assertions.ts
@@ -217,6 +217,28 @@ export async function assertContractSaved(
     chai
       .expect(id(JSON.stringify(contract.metadata)))
       .to.equal(expectedMetadataHash);
+
+    // The metadata must also be dual-written once per compilation into
+    // compiled_contracts_metadata (see issue #2924)
+    const compilationMetadataRes = await sourcifyDatabase.query(
+      `SELECT
+          ccm.metadata
+        FROM sourcify_matches sm
+        JOIN verified_contracts vc ON vc.id = sm.verified_contract_id
+        JOIN contract_deployments cd ON cd.id = vc.deployment_id
+        JOIN compiled_contracts_metadata ccm ON ccm.compilation_id = vc.compilation_id
+        WHERE cd.address = $1 AND cd.chain_id = $2`,
+      [Buffer.from(expectedAddress?.substring(2) ?? "", "hex"), expectedChain],
+    );
+    chai
+      .expect(
+        compilationMetadataRes.rows,
+        "Metadata not stored in compiled_contracts_metadata",
+      )
+      .to.have.length(1);
+    chai
+      .expect(id(JSON.stringify(compilationMetadataRes.rows[0].metadata)))
+      .to.equal(expectedMetadataHash);
   }
 
   // When we'll support runtime_match and creation_match as different statuses we can refine this statement

--- a/services/server/test/helpers/assertions.ts
+++ b/services/server/test/helpers/assertions.ts
@@ -196,11 +196,13 @@ export async function assertContractSaved(
         cd.chain_id,
         sm.creation_match,
         sm.runtime_match,
-        sm.metadata
+        sm.metadata,
+        ccm.metadata AS compilation_metadata
       FROM sourcify_matches sm
       LEFT JOIN verified_contracts vc ON vc.id = sm.verified_contract_id
       LEFT JOIN contract_deployments cd ON cd.id = vc.deployment_id
-      LEFT JOIN compiled_contracts cc ON cc.id = vc.compilation_id 
+      LEFT JOIN compiled_contracts cc ON cc.id = vc.compilation_id
+      LEFT JOIN compiled_contracts_metadata ccm ON ccm.compilation_id = vc.compilation_id
       LEFT JOIN code compiled_runtime_code ON compiled_runtime_code.code_hash = cc.runtime_code_hash
       LEFT JOIN code compiled_creation_code ON compiled_creation_code.code_hash = cc.creation_code_hash
       WHERE cd.address = $1 AND cd.chain_id = $2`,
@@ -218,26 +220,13 @@ export async function assertContractSaved(
       .expect(id(JSON.stringify(contract.metadata)))
       .to.equal(expectedMetadataHash);
 
-    // The metadata must also be dual-written once per compilation into
-    // compiled_contracts_metadata (see issue #2924)
-    const compilationMetadataRes = await sourcifyDatabase.query(
-      `SELECT
-          ccm.metadata
-        FROM sourcify_matches sm
-        JOIN verified_contracts vc ON vc.id = sm.verified_contract_id
-        JOIN contract_deployments cd ON cd.id = vc.deployment_id
-        JOIN compiled_contracts_metadata ccm ON ccm.compilation_id = vc.compilation_id
-        WHERE cd.address = $1 AND cd.chain_id = $2`,
-      [Buffer.from(expectedAddress?.substring(2) ?? "", "hex"), expectedChain],
-    );
+    // The metadata must also be dual-written once per compilation (#2924)
+    chai.expect(
+      contract.compilation_metadata,
+      "Metadata not stored in compiled_contracts_metadata",
+    ).to.not.be.null;
     chai
-      .expect(
-        compilationMetadataRes.rows,
-        "Metadata not stored in compiled_contracts_metadata",
-      )
-      .to.have.length(1);
-    chai
-      .expect(id(JSON.stringify(compilationMetadataRes.rows[0].metadata)))
+      .expect(id(JSON.stringify(contract.compilation_metadata)))
       .to.equal(expectedMetadataHash);
   }
 

--- a/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
+++ b/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
@@ -225,7 +225,8 @@ describe("SourcifyDatabaseService", function () {
 
     // A byte-identical sibling: same compiler/version/language and same
     // bytecodes (so it hits the compiled_contracts dedup constraint), but a
-    // different deployment and different metadata (possible with
+    // different deployment and different metadata (possible when the compiler
+    // omits the metadata hash from the bytecode,
     // settings.metadata.bytecodeHash: "none").
     const siblingVerification = structuredClone(MockVerificationExport);
     siblingVerification.address = "0x1111111111111111111111111111111111111111";

--- a/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
+++ b/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
@@ -216,6 +216,64 @@ describe("SourcifyDatabaseService", function () {
     );
   });
 
+  it("should store metadata once per compilation and keep the first submitter's metadata", async () => {
+    // Store the original contract. This creates a fresh compiled_contracts row
+    // together with its compiled_contracts_metadata row.
+    await databaseService.storeVerification(MockVerificationExport);
+
+    // A byte-identical sibling: same compiler/version/language and same
+    // bytecodes (so it hits the compiled_contracts dedup constraint), but a
+    // different deployment and different metadata (possible with
+    // settings.metadata.bytecodeHash: "none").
+    const siblingVerification = structuredClone(MockVerificationExport);
+    siblingVerification.address = "0x1111111111111111111111111111111111111111";
+    siblingVerification.deploymentInfo.txHash =
+      "0x1111111111111111111111111111111111111111111111111111111111111111";
+    siblingVerification.compilation.metadata = {
+      ...MockVerificationExport.compilation.metadata,
+      output: {
+        ...MockVerificationExport.compilation.metadata.output,
+        devdoc: { kind: "dev", methods: {}, version: 1 },
+      },
+    };
+
+    await databaseService.storeVerification(siblingVerification);
+
+    // The two verifications must share the single deduplicated compilation.
+    const compiledContractsResult = await databaseService.database.pool.query(
+      "SELECT COUNT(*) as count FROM compiled_contracts",
+    );
+    expect(parseInt(compiledContractsResult.rows[0].count)).to.equal(1);
+
+    // Both sourcify_matches keep their own metadata during the dual-write
+    // phase, but the shared compilation must hold exactly one metadata row:
+    // the original contract's.
+    const compilationMetadataResult = await databaseService.database.pool.query(
+      "SELECT metadata FROM compiled_contracts_metadata",
+    );
+    expect(compilationMetadataResult.rows).to.have.length(1);
+    expect(compilationMetadataResult.rows[0].metadata).to.deep.equal(
+      MockVerificationExport.compilation.metadata,
+    );
+  });
+
+  it("should not store a compiled_contracts_metadata row when the compilation has no metadata", async () => {
+    const noMetadataVerification = structuredClone(MockVerificationExport);
+    (noMetadataVerification.compilation as any).metadata = undefined;
+
+    await databaseService.storeVerification(noMetadataVerification);
+
+    const verifiedContractsResult = await databaseService.database.pool.query(
+      "SELECT COUNT(*) as count FROM verified_contracts",
+    );
+    expect(parseInt(verifiedContractsResult.rows[0].count)).to.equal(1);
+
+    const compilationMetadataResult = await databaseService.database.pool.query(
+      "SELECT COUNT(*) as count FROM compiled_contracts_metadata",
+    );
+    expect(parseInt(compilationMetadataResult.rows[0].count)).to.equal(0);
+  });
+
   it("should still store verification even if signature storage fails", async () => {
     sandbox
       .stub(signatureUtil, "extractSignaturesFromAbi")

--- a/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
+++ b/services/server/test/integration/storageServices/SourcifyDatabaseService.spec.ts
@@ -217,6 +217,8 @@ describe("SourcifyDatabaseService", function () {
   });
 
   it("should store metadata once per compilation and keep the first submitter's metadata", async () => {
+    const originalMetadata = MockVerificationExport.compilation.metadata!;
+
     // Store the original contract. This creates a fresh compiled_contracts row
     // together with its compiled_contracts_metadata row.
     await databaseService.storeVerification(MockVerificationExport);
@@ -230,9 +232,9 @@ describe("SourcifyDatabaseService", function () {
     siblingVerification.deploymentInfo.txHash =
       "0x1111111111111111111111111111111111111111111111111111111111111111";
     siblingVerification.compilation.metadata = {
-      ...MockVerificationExport.compilation.metadata,
+      ...originalMetadata,
       output: {
-        ...MockVerificationExport.compilation.metadata.output,
+        ...originalMetadata.output,
         devdoc: { kind: "dev", methods: {}, version: 1 },
       },
     };
@@ -253,7 +255,7 @@ describe("SourcifyDatabaseService", function () {
     );
     expect(compilationMetadataResult.rows).to.have.length(1);
     expect(compilationMetadataResult.rows[0].metadata).to.deep.equal(
-      MockVerificationExport.compilation.metadata,
+      originalMetadata,
     );
   });
 


### PR DESCRIPTION
## Summary

First of two steps for #2924 (option B: a Sourcify-specific side table). Based on #2929 by @peterlodri-sec — same table shape and first-submitter-wins semantics, restructured for a zero-downtime rollout.

- **Migration** creates `compiled_contracts_metadata` (`compilation_id uuid PK → compiled_contracts`, `metadata json NOT NULL`) and nothing else — no in-migration backfill.
- **Backfill** happens out-of-band via `services/database/schema-updates/backfill-compiled-contracts-metadata.mjs`: batched with a keyset cursor, throttled, idempotent (`ON CONFLICT DO NOTHING`), resumable, with `--dry-run` and a `--verify` completeness check. Same pattern as the runtime-code-prefixes backfill from #2918 and the `chain_id` backfill from #2111. The variant picked per compilation is deterministic (lowest `verified_contracts.id`, i.e. first submitter).
- **Server dual-writes**: every stored verification also inserts its compilation's metadata into the side table (first wins). `sourcify_matches.metadata` keeps being written and **remains the only read source** — no read path changes in this PR, so nothing depends on the backfill being complete.

## Rollout

1. Deploy this (migration + dual-write).
2. Run the backfill script; check completeness with `--verify`.
3. Ops: add `compiled_contracts_metadata` to the BigQuery Datastream mirror — the prod stream's include list is an explicit table allowlist, plus the `sourcify_publication` publication on the Postgres side, then an object backfill. **Must happen before step 5**: BigQuery's `public_sourcify_matches` currently mirrors the `metadata` column, so dropping it without mirroring the new table would silently remove metadata from BigQuery.
4. Follow-up PR: switch reads (`STORED_PROPERTIES_TO_SELECTORS`, `getCompilationsByIds`'s LATERAL detour) to the side table and stop writing `sourcify_matches.metadata`.
5. Separate ops task: drop the column and reclaim the ~139 GB with `pg_repack`.

Staging reads through the whole window means no `COALESCE` fallback ever ships.

## Notes

- The column deliberately stays `json`, not `jsonb`: `json` preserves the exact stored text, so the blob keeps hashing to the metadata hash embedded in the onchain bytecode (this property is asserted by the existing test in `assertContractSaved`). The `json` equality limitation doesn't bite here because grouping happens on the table's primary key.
- The dual-write lives in `SourcifyDatabaseService`, not `AbstractDatabaseService`, because the side table is Sourcify-specific and `AllianceDatabaseService` shares the abstract insert path (the Verifier Alliance DB has no such table).
- `assertContractSaved` now also checks the side table, so all existing integration verification tests cover the dual-write; dedicated tests cover first-submitter-wins and the no-metadata (Vyper) case.

## TODO

- [ ] After the migration is deployed, open `sourcify-prod-pg-bq-stream-sourcify-matches` datastream in the GCP console and tick `compiled_contracts_metadata`;

Closes #2929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
