### PR TITLE
chore(renovate): never digest-pin our own ghcr images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,6 +27,11 @@
       "description": "No routine digest churn. A new upstream digest is not evidence that ours is bad, and a rebuilt base image is not reviewable — a weekly stream of opaque hash bumps trains people to rubber-stamp them. We bump a pin deliberately when something tells us the pinned image is actually vulnerable. Note this only stops refreshes of existing pins: pinDigests still adds a digest to any newly introduced image.",
       "matchUpdateTypes": ["digest"],
       "enabled": false
+    },
+    {
+      "description": "Never digest-pin our own images. docker-compose.yml points self-hosters at server:latest on purpose, so a pinned digest would freeze them on one build.",
+      "matchPackageNames": ["ghcr.io/argotorg/sourcify/**"],
+      "pinDigests": false
     }
   ],
   "pinDigests": true,


### PR DESCRIPTION
## Summary

Renovate opened #2925 (pin `ghcr.io/argotorg/sourcify/server` docker tag to a digest) because `pinDigests: true` adds a digest to every image that has none. That is a false positive: `services/server/docker-compose.yml` points self-hosters at `server:latest` on purpose, and a pinned digest would freeze them on one build.

The existing rule that disables `digest` updates does not cover this case, because the first pin is a separate update type (`pinDigest`). This adds a package rule that sets `pinDigests: false` for `ghcr.io/argotorg/sourcify/**`. Third-party images (postgres, node) stay pinned as before.

Closes the Renovate PR #2925 (server digest pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)