### PR TITLE
Add release TODO checks to the release script

### DIFF
--- a/.release-todos/README.md
+++ b/.release-todos/README.md
@@ -1,0 +1,42 @@
+# Release TODOs
+
+A release TODO is a manual step that a person must do around a production deploy, for example:
+
+- apply a database migration on the staging and production databases
+- change a load balancer or Cloud Run setting
+- add a secret or an environment variable
+- run a follow-up script after a migration (see `services/database/README.md`, "schema upgrade scripts")
+
+The release script (`scripts/release/main.sh`) reads every `.md` file in this directory except this README, shows the items at the right time, and deletes the files on the release branch. So the directory only ever holds the open items for the next release.
+
+## When to add a file
+
+Add a file in the same PR that creates the need. Every PR that adds a migration must add one.
+
+## File name
+
+`<pr-number>-<short-name>.md`, for example `2937-drop-idx-code-code-first-75.md`.
+
+## Format
+
+Two optional sections. `before` is shown at the start of the release, before the "Deploy latest to production" PR is created. `after` is shown once that PR is merged. A file with no headings counts as `before`.
+
+```markdown
+## before
+
+- Run `npm run migrate:up` on the staging database
+- Run `npm run migrate:up` on the production database (the drop is instant)
+
+## after
+
+- Delete the old Cloud Run revision
+```
+
+## Safety nets
+
+The release script also, without any file here:
+
+- lists new files under `services/database/migrations/` since the last deploy
+- lists added lines that contain `TODO_RELEASE` since the last deploy
+
+Both only look at `git diff master...staging`, so an item shows up for exactly one release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,7 @@ The server supports multiple storage backends:
 
 - For Sourcify-specific changes: Add migration in `services/database/migrations/`
 - For Verifier Alliance changes: Update submodule in `services/database/database-specs/`
+- Every PR that adds a migration must add a file `.release-todos/<pr-number>-<short-name>.md`. The same applies to any manual step around a production deploy (load balancer, Cloud Run settings, secrets, follow-up scripts). Format and examples: `.release-todos/README.md`. The release script shows these files and deletes them.
 
 ### API and Documentation Maintenance
 
@@ -208,6 +209,7 @@ The `FIELDS_TO_STORED_PROPERTIES` map is the authoritative source used by the va
 When reviewing PRs as an automated agent:
 
 - Check database migration safety (services/database/) — flag destructive operations
+- Flag a PR that adds a migration or needs a manual deploy step but adds no `.release-todos/` file
 - Verify API changes maintain backwards compatibility for the v2 endpoints
 - Check that changes to packages/ don't break dependent services (server, monitor)
 - Verify the OpenAPI/Swagger spec (`apiv2.yaml`) is updated if API endpoints or response fields change — including the **Available fields** section and the `fields` query parameter description

--- a/scripts/release/git_utils.sh
+++ b/scripts/release/git_utils.sh
@@ -65,7 +65,8 @@ create_gh_deploy_pr() {
 
   if $CREATE_PR; then
     echo "Creating a PR for the staging branch"
-    gh pr create --title "Deploy latest to production" --body "" --head staging --base master
+    # RELEASE_TODO_TEXT is collected by check_release_todos (release_todos.sh)
+    gh pr create --title "Deploy latest to production" --body "${RELEASE_TODO_TEXT:-}" --head staging --base master
     if [ $? -ne 0 ]; then
       error_exit "Failed to create PR. Exiting."
     fi
@@ -97,7 +98,7 @@ create_new_branch() {
 }
 
 commit_changelogs() {
-  git commit -m "Update changelogs"
+  git commit -m "Update changelogs and clear release TODOs"
 }
 
 # Function to select a branch name

--- a/scripts/release/main.sh
+++ b/scripts/release/main.sh
@@ -13,12 +13,14 @@ source "${SCRIPT_DIR}/logging_utils.sh"
 source "${SCRIPT_DIR}/git_utils.sh"
 source "${SCRIPT_DIR}/release_data_utils.sh"
 source "${SCRIPT_DIR}/release.sh"
+source "${SCRIPT_DIR}/release_todos.sh"
 
 ###
 ### Main
 ###
 prompt_execute_or_skip "checking current branch" is_on_staging_branch
 prompt_execute_or_skip "checking if branches are in sync" check_branch_sync
+prompt_execute_or_skip "checking for open release TODOs (migrations, .release-todos/, TODO_RELEASE markers)" check_release_todos
 prompt_execute_or_skip "creating GitHub PR" create_gh_deploy_pr
 
 # Needed if the user skips creating the PR
@@ -27,6 +29,7 @@ if [ -z "$OPEN_PR_NUMBER" ]; then
 fi
 
 prompt_execute_or_skip "creating new branch because we can't commit to staging directly" create_new_branch "release-$(date +'%Y-%m-%d-%H-%M')" # Add hour and minute to the branch name if we do multiple releases in the same day
+prompt_execute_or_skip "removing the done .release-todos files (committed with the changelogs)" clear_release_todo_files
 prompt_execute_or_skip "choosing versions for each package and writing changelogs" update_packages_and_changelog
 prompt_execute_or_skip "commiting the changelogs" commit_changelogs
 
@@ -39,6 +42,8 @@ prompt_execute_or_skip "pushing the tags to GitHub" push_tags_in_order
 prompt_execute_or_skip "creating GitHub releases" create_github_releases
 
 prompt_execute_or_skip "asking if 'Deploy latest to production' PR is merged" ask_if_master_pr_merged
+prompt_execute_or_skip "showing release TODOs for after the deploy" show_release_todos_after
 
 # Clean up the temporary package data file
 prompt_execute_or_skip "cleaning up temporary release data" cleanup_package_data_file
+prompt_execute_or_skip "cleaning up temporary release TODO data" cleanup_release_todos_file

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -233,7 +233,7 @@ update_changelog() {
 }
 
 commit_changelogs() {
-  git commit -m "Update changelogs"
+  git commit -m "Update changelogs and clear release TODOs"
 }
 
 ###

--- a/scripts/release/release_todos.sh
+++ b/scripts/release/release_todos.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# Release TODOs: manual steps that must happen around a production deploy.
+#
+# Three sources, all scoped to what is new for production (git diff master...staging):
+#   1. Files in .release-todos/ (see .release-todos/README.md). Each file can have a
+#      "## before" and an "## after" section. "before" items are shown at the start of
+#      the release, "after" items once the deploy PR is merged.
+#   2. New migration files under services/database/ (always a "before" item).
+#   3. Added lines containing TODO_RELEASE anywhere in the diff (safety net).
+
+source "${SCRIPT_DIR}/logging_utils.sh"
+
+RELEASE_TODOS_DIR=".release-todos"
+# Persists "after" items across script steps, like .release_package_data.tmp does for packages.
+RELEASE_TODOS_AFTER_FILE="${SCRIPT_DIR}/.release_todos_after.tmp"
+# Collected "before" text; used as the body of the deploy PR.
+RELEASE_TODO_TEXT=""
+
+# Prints the given section of a release-todo file ("before" or "after").
+# A file with no "## before"/"## after" headings counts as "before".
+todo_section() {
+  local file=$1
+  local section=$2
+  if ! grep -qiE '^## *(before|after) *$' "$file"; then
+    [ "$section" = "before" ] && cat "$file"
+    return
+  fi
+  awk -v want="$section" '
+    /^## / { on = (tolower($2) == want); next }
+    on { print }
+  ' "$file"
+}
+
+confirm_or_exit() {
+  local question=$1
+  read -p "$question (y/N): " ok
+  [[ $ok == [yY] || $ok == [yY][eE][sS] ]] || error_exit "Finish the release TODOs first, then run the script again."
+}
+
+check_new_migrations() {
+  local files
+  files=$(git diff --name-only master...staging -- services/database/migrations/ services/database/database-specs)
+  [ -z "$files" ] && return
+  warn "New database migrations since the last production deploy:"
+  echo "$files"
+  echo "Run 'npm run migrate:up' (services/database) against the staging and production databases."
+  RELEASE_TODO_TEXT+=$'\n## New migrations (apply on staging and production)\n'"$files"$'\n'
+  confirm_or_exit "Applied on staging AND production?"
+}
+
+check_release_todo_files() {
+  local file
+  >"$RELEASE_TODOS_AFTER_FILE"
+  for file in "$RELEASE_TODOS_DIR"/*.md; do
+    [ -f "$file" ] || continue
+    [ "$(basename "$file")" = "README.md" ] && continue
+    local before after
+    before=$(todo_section "$file" before)
+    after=$(todo_section "$file" after)
+    if [ -n "$after" ]; then
+      printf '### %s\n%s\n\n' "$(basename "$file")" "$after" >>"$RELEASE_TODOS_AFTER_FILE"
+    fi
+    [ -z "$before" ] && continue
+    warn "Release TODO ($file), before the deploy:"
+    echo "$before"
+    RELEASE_TODO_TEXT+=$'\n## Before deploy: '"$(basename "$file")"$'\n'"$before"$'\n'
+    confirm_or_exit "Done?"
+  done
+  if [ -s "$RELEASE_TODOS_AFTER_FILE" ]; then
+    RELEASE_TODO_TEXT+=$'\n## After deploy\n'"$(cat "$RELEASE_TODOS_AFTER_FILE")"$'\n'
+  fi
+}
+
+check_release_todo_markers() {
+  local hits
+  hits=$(git diff master...staging -U0 | awk '
+    /^\+\+\+ / { file = substr($2, 3); next }
+    /^\+/ && /TODO_RELEASE/ { print file ": " substr($0, 2) }
+  ')
+  [ -z "$hits" ] && return
+  warn "TODO_RELEASE markers in changes since the last production deploy:"
+  echo "$hits"
+  RELEASE_TODO_TEXT+=$'\n## TODO_RELEASE markers\n'"$hits"$'\n'
+  confirm_or_exit "All of these done?"
+}
+
+# Runs at the start of the release, before the deploy PR is created.
+check_release_todos() {
+  check_new_migrations
+  check_release_todo_files
+  check_release_todo_markers
+  if [ -z "$RELEASE_TODO_TEXT" ]; then
+    echo "No open release TODOs."
+  fi
+}
+
+# Deletes the release-todo files and stages the deletion for the release branch commit.
+clear_release_todo_files() {
+  local file
+  for file in "$RELEASE_TODOS_DIR"/*.md; do
+    [ -f "$file" ] || continue
+    [ "$(basename "$file")" = "README.md" ] && continue
+    git rm -q "$file"
+    echo "Removed $file"
+  done
+}
+
+# Runs at the end of the release, after the deploy PR is merged.
+show_release_todos_after() {
+  if [ ! -s "$RELEASE_TODOS_AFTER_FILE" ]; then
+    echo "No release TODOs for after the deploy."
+    return
+  fi
+  warn "Release TODOs to do now, after the deploy:"
+  cat "$RELEASE_TODOS_AFTER_FILE"
+  confirm_or_exit "All done?"
+}
+
+cleanup_release_todos_file() {
+  [ -f "$RELEASE_TODOS_AFTER_FILE" ] && rm "$RELEASE_TODOS_AFTER_FILE"
+  return 0
+}

--- a/services/database/README.md
+++ b/services/database/README.md
@@ -31,6 +31,8 @@ After updating the submodule, the schema dump `sourcify-database.sql` should be 
 
 Any new migration should be capable of updating the live Sourcify staging and production databases.
 
+Migrations are applied by hand, not by CI. Every PR that adds a migration must also add a file in [`.release-todos/`](../../.release-todos/README.md), so the release script reminds the person who releases to apply it on staging and production.
+
 Please also see the section on [schema upgrade scripts](#schema-upgrade-scripts) as some migrations on a live database might require running a follow-up script to complete the schema change.
 
 ### Prerequisites
@@ -106,11 +108,11 @@ The scripts are idempotent, resumable and they only touch rows that still need w
 
 ### Available upgrade scripts
 
-| Script                                                                                | When to run                                                                                                                                                               | What it does                                                                           |
-| ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------- |
-| [`post-v0-to-v1-upgrade.mjs`](./schema-updates/post-v0-to-v1-upgrade.mjs)             | After upgrading to the v1 schema, once the `sources` table is populated.                                                                                                  | Backfills `sources.source_hash_keccak` with the keccak256 hash of each source.         |
-| [`post-v2.12-to-v2.13-upgrade.mjs`](./schema-updates/post-v2.12-to-v2.13-upgrade.mjs) | After applying the v2.13 migration that adds the nullable `sourcify_matches.chain_id` column, and before applying the follow-up migration that promotes it to `NOT NULL`. | Backfills `sourcify_matches.chain_id` from `contract_deployments.chain_id` in batches. |
-| [`backfill-compiled-contracts-runtime-code-prefixes.mjs`](./schema-updates/backfill-compiled-contracts-runtime-code-prefixes.mjs) | After applying the migration that adds the `compiled_contracts_runtime_code_prefixes` table, and before deploying server version 3.18.0. | Backfills `compiled_contracts_runtime_code_prefixes` (first 75 bytes of each compilation's runtime code) for compilations that existed before the migration's insert trigger. |
+| Script                                                                                                                            | When to run                                                                                                                                                               | What it does                                                                                                                                                                  |
+| --------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`post-v0-to-v1-upgrade.mjs`](./schema-updates/post-v0-to-v1-upgrade.mjs)                                                         | After upgrading to the v1 schema, once the `sources` table is populated.                                                                                                  | Backfills `sources.source_hash_keccak` with the keccak256 hash of each source.                                                                                                |
+| [`post-v2.12-to-v2.13-upgrade.mjs`](./schema-updates/post-v2.12-to-v2.13-upgrade.mjs)                                             | After applying the v2.13 migration that adds the nullable `sourcify_matches.chain_id` column, and before applying the follow-up migration that promotes it to `NOT NULL`. | Backfills `sourcify_matches.chain_id` from `contract_deployments.chain_id` in batches.                                                                                        |
+| [`backfill-compiled-contracts-runtime-code-prefixes.mjs`](./schema-updates/backfill-compiled-contracts-runtime-code-prefixes.mjs) | After applying the migration that adds the `compiled_contracts_runtime_code_prefixes` table, and before deploying server version 3.18.0.                                  | Backfills `compiled_contracts_runtime_code_prefixes` (first 75 bytes of each compilation's runtime code) for compilations that existed before the migration's insert trigger. |
 
 Run a script with:
 


### PR DESCRIPTION
## Summary

Manual steps around a production deploy were easy to forget, because the release script only looked at package versions. Migrations are applied by hand, and the "Deploy latest to production" PR had an empty body. See the discussion on #2937 (drop `idx_code_code_first_75`).

This adds `scripts/release/release_todos.sh`, wired into `main.sh`:

- **`.release-todos/<pr-number>-<short-name>.md`** files with optional `## before` and `## after` sections. `before` items are shown at the start of the release, `after` items once the deploy PR is merged. The script deletes the files on the release branch, so the directory only holds open items.
- **New migration files** since the last deploy are listed automatically, with a reminder to apply them on staging and production.
- **`TODO_RELEASE` markers** in added lines are listed as a safety net.
- All collected items become the body of the "Deploy latest to production" PR, so its reviewer sees the same list.

Everything is scoped to `git diff master...staging`, so an item shows up for exactly one release.

## Notes

- `.release-todos/README.md` documents the format. `services/database/README.md` and `CLAUDE.md` now say that every migration PR must add such a file.
- Not included: a CI check that fails a migration PR without a `.release-todos/` file. Can follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)