### PR TITLE
ci: split live creation-tx API tests into their own CI job

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -170,8 +170,6 @@ workflows:
           requires: [build-and-lint]
       - test-4byte:
           requires: [build-and-lint]
-      # Live third-party API tests. Not required by any other job: a red run
-      # means a provider is down, not that the code is broken.
       - test-creation-tx-apis:
           requires: [build-and-lint]
       # TODO: run-build options are not taking affect. We build them always.
@@ -237,8 +235,6 @@ workflows:
           requires: [build-and-lint]
       - test-4byte:
           requires: [build-and-lint]
-      # Live third-party API tests. Not required by any other job: a red run
-      # means a provider is down, not that the code is broken.
       - test-creation-tx-apis:
           requires: [build-and-lint]
   database-schema-validation:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -170,6 +170,10 @@ workflows:
           requires: [build-and-lint]
       - test-4byte:
           requires: [build-and-lint]
+      # Live third-party API tests. Not required by any other job: a red run
+      # means a provider is down, not that the code is broken.
+      - test-creation-tx-apis:
+          requires: [build-and-lint]
       # TODO: run-build options are not taking affect. We build them always.
       - build-push-monitor-amd64:
           run-build: << pipeline.parameters.run-build-monitor >>
@@ -232,6 +236,10 @@ workflows:
       - test-server:
           requires: [build-and-lint]
       - test-4byte:
+          requires: [build-and-lint]
+      # Live third-party API tests. Not required by any other job: a red run
+      # means a provider is down, not that the code is broken.
+      - test-creation-tx-apis:
           requires: [build-and-lint]
   database-schema-validation:
     when: << pipeline.parameters.run-validate-database-schema >>
@@ -441,6 +449,18 @@ jobs:
           name: create lcov report
           command: npx lerna run cov:lcov --scope=sourcify-server
       - codecov/upload
+  test-creation-tx-apis:
+    docker:
+      - image: cimg/node:22.22.0@sha256:2c1320ee6a256628f698938038700911276310d40cc9887cfc8f66ec0daa4343
+    resource_class: small
+    working_directory: ~/sourcify
+    steps:
+      - checkout
+      - attach_workspace:
+          at: ~/sourcify
+      - run:
+          name: test live creation-tx APIs
+          command: cd services/server && npm run test:creation-tx-apis
   test-4byte:
     docker:
       - image: cimg/node:22.22.0@sha256:2c1320ee6a256628f698938038700911276310d40cc9887cfc8f66ec0daa4343

--- a/services/server/package.json
+++ b/services/server/package.json
@@ -17,6 +17,7 @@
     "postgres-test:stop": "docker-compose -f test/docker-compose.yml rm -fsv",
     "postgres-test:migrate": "cd ../database && git submodule update --init && SERVICE_NAME=server DATABASE_URL=postgres://sourcify:sourcify@${SOURCIFY_POSTGRES_HOST:-sourcify-db}:${DOCKER_HOST_POSTGRES_TEST_PORT:-5432}/sourcify?sslmode=disable DBMATE_SCHEMA_FILE=./sourcify-database.sql npm run migrate:up-no-dump",
     "test:unit": "mocha  --exit --recursive test/unit/**",
+    "test:creation-tx-apis": "mocha --exit --recursive test/creation-tx-apis/**",
     "test": "npm run postgres-test:migrate & npx c8 --reporter=none mocha --exit --recursive test/unit/** test/integration/**",
     "test-local": "export DOCKER_HOST_POSTGRES_TEST_PORT=${DOCKER_HOST_POSTGRES_TEST_PORT:-5431} && npm run postgres-test:start && sleep 2 && SOURCIFY_POSTGRES_HOST=localhost npm run test; status=$?; npm run postgres-test:stop; exit $status",
     "generate-test-case": "ts-node test/integration/verification-cases/generate-test-case.ts",

--- a/services/server/test/creation-tx-apis/contract-creation.spec.ts
+++ b/services/server/test/creation-tx-apis/contract-creation.spec.ts
@@ -1,0 +1,234 @@
+import chai from "chai";
+import { getCreatorTx } from "../../src/server/services/utils/contract-creation-util";
+import { ChainRepository } from "../../src/sourcify-chain-repository";
+import type {
+  FetchContractCreationTxMethod,
+  SourcifyChainMap,
+} from "@ethereum-sourcify/lib-sourcify";
+import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
+
+// These tests call the live third-party creation-tx APIs (Blockscout,
+// Routescan, Etherscan, NodeReal, ...). They run in the separate
+// test-creation-tx-apis CI job, which is not required by any other job:
+// a red run means a provider is failing, not that the code is broken.
+describe("creation-tx APIs (live)", function () {
+  let sourcifyChainsMap: SourcifyChainMap;
+
+  // Build the chain map manually instead of calling initializeSourcifyChains.
+  // The real loader requires API keys (DRPC, QuickNode, etc.) that aren't
+  // available in CI, but getCreatorTx itself only needs the
+  // fetchContractCreationTxUsing / etherscanApi config — the RPCs aren't
+  // exercised. A dummy http://localhost/ entry satisfies SourcifyChain's
+  // "at least one RPC" requirement without hitting the network.
+  before(async () => {
+    const dummyRpcs = [{ rpc: "http://localhost/" }];
+    sourcifyChainsMap = {
+      "1": new SourcifyChain({
+        name: "Ethereum Mainnet",
+        chainId: 1,
+        supported: true,
+        rpcs: dummyRpcs,
+        fetchContractCreationTxUsing: {
+          etherscanApi: true,
+          blockscoutApi: { url: "https://eth.blockscout.com/" },
+          routescanApi: { type: "mainnet" },
+        },
+        etherscanApi: {
+          supported: true,
+          apiKeyEnvName: "ETHERSCAN_API_KEY_MAINNET",
+        },
+      }),
+      "23294": new SourcifyChain({
+        name: "Oasis Sapphire Mainnet",
+        chainId: 23294,
+        supported: true,
+        rpcs: dummyRpcs,
+        fetchContractCreationTxUsing: {
+          nexusApi: {
+            url: "https://nexus.oasis.io/",
+            runtime: "sapphire",
+          },
+        },
+      }),
+      "43114": new SourcifyChain({
+        name: "Avalanche C-Chain",
+        chainId: 43114,
+        supported: true,
+        rpcs: dummyRpcs,
+        fetchContractCreationTxUsing: {
+          etherscanApi: true,
+          routescanApi: { type: "mainnet" },
+          avalancheApi: true,
+        },
+        etherscanApi: {
+          supported: true,
+          apiKeyEnvName: "ETHERSCAN_API_KEY_AVALANCHE",
+        },
+      }),
+      "56": new SourcifyChain({
+        name: "BNB Smart Chain Mainnet",
+        chainId: 56,
+        supported: true,
+        rpcs: dummyRpcs,
+        fetchContractCreationTxUsing: {
+          nodeRealApi: {
+            url: "https://bsc-mainnet.nodereal.io/v1/${API_KEY}",
+          },
+          etherscanApi: true,
+        },
+        etherscanApi: {
+          supported: true,
+          apiKeyEnvName: "ETHERSCAN_API_KEY_BSC",
+        },
+      }),
+      "100009": new SourcifyChain({
+        name: "VeChain Mainnet",
+        chainId: 100009,
+        supported: true,
+        rpcs: dummyRpcs,
+        fetchContractCreationTxUsing: {
+          veChainApi: true,
+        },
+      }),
+    };
+  });
+
+  // Commenting out as fails way too often
+  // it("should run getCreatorTx with chainId 51", async function () {
+  //   const sourcifyChain = sourcifyChainsArray.find(
+  //     (sourcifyChain) => sourcifyChain.chainId === 51
+  //   );
+  //   if (!sourcifyChain) {
+  //     chai.assert.fail("No chain for chainId 51 configured");
+  //   }
+  //   const creatorTx = await getCreatorTx(
+  //     sourcifyChain,
+  //     "0x8C3FA94eb5b07c9AF7dBFcC53ea3D2BF7FdF3617"
+  //   );
+  //   chai
+  //     .expect(creatorTx)
+  //     .equals(
+  //       "0xb1af0ec1283551480ae6e6ce374eb4fa7d1803109b06657302623fc65c987420"
+  //     );
+  // });
+
+  it("should run getCreatorTx with nexusApi for Nexus", async function () {
+    const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
+      .sourcifyChainsArray;
+    const sourcifyChain = sourcifyChainsArray.find(
+      (sourcifyChain) => sourcifyChain.chainId === 23294,
+    );
+    if (!sourcifyChain) {
+      chai.assert.fail("No chain for chainId 23294 configured");
+    }
+    const creatorTx = await getCreatorTx(
+      sourcifyChain,
+      "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
+    );
+    chai
+      .expect(creatorTx)
+      .equals(
+        "0xce775b521cc6e1341020560441d77cd634b0972fc34bf96f79e9fab81caa8ab7",
+      );
+  });
+
+  // Test each fetchContractCreationTxUsing method
+  // We can use the Mainnet to test all below as all support Mainnet
+  const testCases: {
+    type: FetchContractCreationTxMethod;
+    chainId: number;
+    address: string;
+    txHash: string;
+  }[] = [
+    {
+      type: "blockscoutApi",
+      chainId: 1,
+      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+      txHash:
+        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
+    },
+    {
+      type: "routescanApi",
+      chainId: 1,
+      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+      txHash:
+        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
+    },
+    {
+      type: "etherscanApi",
+      chainId: 1,
+      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
+      txHash:
+        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
+    },
+    {
+      type: "avalancheApi",
+      chainId: 43114,
+      address: "0xf3D455D5e756EfceC05C49E5721b539265466bbB",
+      txHash:
+        "0x7790ee646f9cf4d4ec0d2e9dbb4943e606d18bab0e36fe71075b0a8246c6be4e",
+    },
+    {
+      type: "veChainApi",
+      chainId: 100009,
+      address: "0xae4c53b120cba91a44832f875107cbc8fbee185c",
+      txHash:
+        "0x0ace736bc4ad5a25e2493d71fbc3315e422068ecefb3715d86ea85ab0ba26716",
+    },
+    {
+      type: "nodeRealApi",
+      chainId: 56,
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      txHash:
+        "0xcc0ddf5f791617ba9befce57995dbcb3a202946a1eefa3469742b01a0decdaf2",
+    },
+  ];
+  for (const testCase of testCases) {
+    it(`should run getCreatorTx with ${testCase.type}`, async function () {
+      const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
+        .sourcifyChainsArray;
+      const sourcifyChain = sourcifyChainsArray.find(
+        (sourcifyChain) => sourcifyChain.chainId === testCase.chainId,
+      );
+      if (!sourcifyChain) {
+        chai.assert.fail(`No chain for chainId ${testCase.chainId} configured`);
+      }
+
+      // Don't run if it's an external PR. Etherscan tests need API keys that can't be exposed to external PRs.
+      if (
+        (testCase.type === "etherscanApi" || testCase.type === "veChainApi") &&
+        process.env.CIRCLE_PR_REPONAME !== undefined
+      ) {
+        console.log(`Skipping ${testCase.type} test for external PR`);
+        return;
+      }
+
+      // Skip nodeRealApi test if NODEREAL_API_KEY is not set
+      if (testCase.type === "nodeRealApi" && !process.env.NODEREAL_API_KEY) {
+        console.log(`Skipping nodeRealApi test: NODEREAL_API_KEY not set`);
+        return;
+      }
+
+      // Remove all other fetchContractCreationTxUsing methods except the one we're testing
+      const testChain = Object.create(
+        Object.getPrototypeOf(sourcifyChain),
+        Object.getOwnPropertyDescriptors(sourcifyChain),
+      );
+      if (testChain.fetchContractCreationTxUsing) {
+        testChain.fetchContractCreationTxUsing = {
+          [testCase.type]:
+            testChain.fetchContractCreationTxUsing[testCase.type],
+        };
+      }
+      // Block the getBlockNumber call to block the binary search
+      testChain.getBlockNumber = async () => {
+        throw new Error("Blocked getBlockNumber");
+      };
+
+      const creatorTx = await getCreatorTx(testChain, testCase.address);
+      chai
+        .expect(creatorTx)
+        .equals(testCase.txHash, `Failed for ${testCase.type}`);
+    });
+  }
+});

--- a/services/server/test/creation-tx-apis/contract-creation.spec.ts
+++ b/services/server/test/creation-tx-apis/contract-creation.spec.ts
@@ -86,25 +86,6 @@ describe("creation-tx APIs (live)", function () {
     };
   });
 
-  // Commenting out as fails way too often
-  // it("should run getCreatorTx with chainId 51", async function () {
-  //   const sourcifyChain = sourcifyChainsArray.find(
-  //     (sourcifyChain) => sourcifyChain.chainId === 51
-  //   );
-  //   if (!sourcifyChain) {
-  //     chai.assert.fail("No chain for chainId 51 configured");
-  //   }
-  //   const creatorTx = await getCreatorTx(
-  //     sourcifyChain,
-  //     "0x8C3FA94eb5b07c9AF7dBFcC53ea3D2BF7FdF3617"
-  //   );
-  //   chai
-  //     .expect(creatorTx)
-  //     .equals(
-  //       "0xb1af0ec1283551480ae6e6ce374eb4fa7d1803109b06657302623fc65c987420"
-  //     );
-  // });
-
   it("should run getCreatorTx with nexusApi for Nexus", async function () {
     const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
       .sourcifyChainsArray;

--- a/services/server/test/creation-tx-apis/contract-creation.spec.ts
+++ b/services/server/test/creation-tx-apis/contract-creation.spec.ts
@@ -7,19 +7,12 @@ import type {
 } from "@ethereum-sourcify/lib-sourcify";
 import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 
-// These tests call the live third-party creation-tx APIs (Blockscout,
-// Routescan, Etherscan, NodeReal, ...). They run in the separate
-// test-creation-tx-apis CI job, which is not required by any other job:
-// a red run means a provider is failing, not that the code is broken.
+// Tests against live third-party APIs, run in the non-blocking test-creation-tx-apis CI job.
 describe("creation-tx APIs (live)", function () {
   let sourcifyChainsMap: SourcifyChainMap;
 
-  // Build the chain map manually instead of calling initializeSourcifyChains.
-  // The real loader requires API keys (DRPC, QuickNode, etc.) that aren't
-  // available in CI, but getCreatorTx itself only needs the
-  // fetchContractCreationTxUsing / etherscanApi config — the RPCs aren't
-  // exercised. A dummy http://localhost/ entry satisfies SourcifyChain's
-  // "at least one RPC" requirement without hitting the network.
+  // The dummy RPC satisfies SourcifyChain's "at least one RPC" requirement; only
+  // the fetchContractCreationTxUsing / etherscanApi config is exercised.
   before(async () => {
     const dummyRpcs = [{ rpc: "http://localhost/" }];
     sourcifyChainsMap = {

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -4,24 +4,19 @@ import {
   findContractCreationTxByBinarySearchWithTimeout,
   getCreatorTx,
 } from "../../../src/server/services/utils/contract-creation-util";
-import { ChainRepository } from "../../../src/sourcify-chain-repository";
-import type {
-  FetchContractCreationTxMethod,
-  SourcifyChainMap,
-} from "@ethereum-sourcify/lib-sourcify";
+import type { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
 import sinon from "sinon";
 import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { findContractCreationTxByBinarySearch } from "../../../src/server/services/utils/contract-creation-util";
 
+// Tests that call the live creation-tx APIs (Blockscout, NodeReal, ...) live
+// in test/creation-tx-apis/ and run in the separate test-creation-tx-apis CI
+// job, so a provider outage doesn't fail test-server.
 describe("contract creation util", function () {
   let sourcifyChainsMap: SourcifyChainMap;
 
-  // Build the chain map manually instead of calling initializeSourcifyChains.
-  // The real loader requires API keys (DRPC, QuickNode, etc.) that aren't
-  // available in CI, but getCreatorTx itself only needs the
-  // fetchContractCreationTxUsing / etherscanApi config — the RPCs aren't
-  // exercised. A dummy http://localhost/ entry satisfies SourcifyChain's
-  // "at least one RPC" requirement without hitting the network.
+  // A dummy http://localhost/ RPC satisfies SourcifyChain's "at least one RPC"
+  // requirement without hitting the network.
   before(async () => {
     const dummyRpcs = [{ rpc: "http://localhost/" }];
     sourcifyChainsMap = {
@@ -40,98 +35,7 @@ describe("contract creation util", function () {
           apiKeyEnvName: "ETHERSCAN_API_KEY_MAINNET",
         },
       }),
-      "23294": new SourcifyChain({
-        name: "Oasis Sapphire Mainnet",
-        chainId: 23294,
-        supported: true,
-        rpcs: dummyRpcs,
-        fetchContractCreationTxUsing: {
-          nexusApi: {
-            url: "https://nexus.oasis.io/",
-            runtime: "sapphire",
-          },
-        },
-      }),
-      "43114": new SourcifyChain({
-        name: "Avalanche C-Chain",
-        chainId: 43114,
-        supported: true,
-        rpcs: dummyRpcs,
-        fetchContractCreationTxUsing: {
-          etherscanApi: true,
-          routescanApi: { type: "mainnet" },
-          avalancheApi: true,
-        },
-        etherscanApi: {
-          supported: true,
-          apiKeyEnvName: "ETHERSCAN_API_KEY_AVALANCHE",
-        },
-      }),
-      "56": new SourcifyChain({
-        name: "BNB Smart Chain Mainnet",
-        chainId: 56,
-        supported: true,
-        rpcs: dummyRpcs,
-        fetchContractCreationTxUsing: {
-          nodeRealApi: {
-            url: "https://bsc-mainnet.nodereal.io/v1/${API_KEY}",
-          },
-          etherscanApi: true,
-        },
-        etherscanApi: {
-          supported: true,
-          apiKeyEnvName: "ETHERSCAN_API_KEY_BSC",
-        },
-      }),
-      "100009": new SourcifyChain({
-        name: "VeChain Mainnet",
-        chainId: 100009,
-        supported: true,
-        rpcs: dummyRpcs,
-        fetchContractCreationTxUsing: {
-          veChainApi: true,
-        },
-      }),
     };
-  });
-
-  // Commenting out as fails way too often
-  // it("should run getCreatorTx with chainId 51", async function () {
-  //   const sourcifyChain = sourcifyChainsArray.find(
-  //     (sourcifyChain) => sourcifyChain.chainId === 51
-  //   );
-  //   if (!sourcifyChain) {
-  //     chai.assert.fail("No chain for chainId 51 configured");
-  //   }
-  //   const creatorTx = await getCreatorTx(
-  //     sourcifyChain,
-  //     "0x8C3FA94eb5b07c9AF7dBFcC53ea3D2BF7FdF3617"
-  //   );
-  //   chai
-  //     .expect(creatorTx)
-  //     .equals(
-  //       "0xb1af0ec1283551480ae6e6ce374eb4fa7d1803109b06657302623fc65c987420"
-  //     );
-  // });
-
-  it("should run getCreatorTx with nexusApi for Nexus", async function () {
-    const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
-      .sourcifyChainsArray;
-    const sourcifyChain = sourcifyChainsArray.find(
-      (sourcifyChain) => sourcifyChain.chainId === 23294,
-    );
-    if (!sourcifyChain) {
-      chai.assert.fail("No chain for chainId 23294 configured");
-    }
-    const creatorTx = await getCreatorTx(
-      sourcifyChain,
-      "0x8Bc2B030b299964eEfb5e1e0b36991352E56D2D3",
-    );
-    chai
-      .expect(creatorTx)
-      .equals(
-        "0xce775b521cc6e1341020560441d77cd634b0972fc34bf96f79e9fab81caa8ab7",
-      );
   });
 
   describe("Etherscan API key handling for getCreatorTx", function () {
@@ -193,106 +97,6 @@ describe("contract creation util", function () {
       chai.expect(calledUrl).to.include(GLOBAL_KEY);
     });
   });
-
-  // Test each fetchContractCreationTxUsing method
-  // We can use the Mainnet to test all below as all support Mainnet
-  const testCases: {
-    type: FetchContractCreationTxMethod;
-    chainId: number;
-    address: string;
-    txHash: string;
-  }[] = [
-    {
-      type: "blockscoutApi",
-      chainId: 1,
-      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-      txHash:
-        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
-    },
-    {
-      type: "routescanApi",
-      chainId: 1,
-      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-      txHash:
-        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
-    },
-    {
-      type: "etherscanApi",
-      chainId: 1,
-      address: "0x00000000219ab540356cBB839Cbe05303d7705Fa",
-      txHash:
-        "0xe75fb554e433e03763a1560646ee22dcb74e5274b34c5ad644e7c0f619a7e1d0",
-    },
-    {
-      type: "avalancheApi",
-      chainId: 43114,
-      address: "0xf3D455D5e756EfceC05C49E5721b539265466bbB",
-      txHash:
-        "0x7790ee646f9cf4d4ec0d2e9dbb4943e606d18bab0e36fe71075b0a8246c6be4e",
-    },
-    {
-      type: "veChainApi",
-      chainId: 100009,
-      address: "0xae4c53b120cba91a44832f875107cbc8fbee185c",
-      txHash:
-        "0x0ace736bc4ad5a25e2493d71fbc3315e422068ecefb3715d86ea85ab0ba26716",
-    },
-    {
-      type: "nodeRealApi",
-      chainId: 56,
-      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
-      txHash:
-        "0xcc0ddf5f791617ba9befce57995dbcb3a202946a1eefa3469742b01a0decdaf2",
-    },
-  ];
-  for (const testCase of testCases) {
-    it(`should run getCreatorTx with ${testCase.type}`, async function () {
-      const sourcifyChainsArray = new ChainRepository(sourcifyChainsMap)
-        .sourcifyChainsArray;
-      const sourcifyChain = sourcifyChainsArray.find(
-        (sourcifyChain) => sourcifyChain.chainId === testCase.chainId,
-      );
-      if (!sourcifyChain) {
-        chai.assert.fail(`No chain for chainId ${testCase.chainId} configured`);
-      }
-
-      // Don't run if it's an external PR. Etherscan tests need API keys that can't be exposed to external PRs.
-      if (
-        (testCase.type === "etherscanApi" || testCase.type === "veChainApi") &&
-        process.env.CIRCLE_PR_REPONAME !== undefined
-      ) {
-        console.log(`Skipping ${testCase.type} test for external PR`);
-        return;
-      }
-
-      // Skip nodeRealApi test if NODEREAL_API_KEY is not set
-      if (testCase.type === "nodeRealApi" && !process.env.NODEREAL_API_KEY) {
-        console.log(`Skipping nodeRealApi test: NODEREAL_API_KEY not set`);
-        return;
-      }
-
-      // Remove all other fetchContractCreationTxUsing methods except the one we're testing
-      const testChain = Object.create(
-        Object.getPrototypeOf(sourcifyChain),
-        Object.getOwnPropertyDescriptors(sourcifyChain),
-      );
-      if (testChain.fetchContractCreationTxUsing) {
-        testChain.fetchContractCreationTxUsing = {
-          [testCase.type]:
-            testChain.fetchContractCreationTxUsing[testCase.type],
-        };
-      }
-      // Block the getBlockNumber call to block the binary search
-      testChain.getBlockNumber = async () => {
-        throw new Error("Blocked getBlockNumber");
-      };
-
-      const creatorTx = await getCreatorTx(testChain, testCase.address);
-      chai
-        .expect(creatorTx)
-        .equals(testCase.txHash, `Failed for ${testCase.type}`);
-    });
-  }
 
   describe("findContractCreationTxByBinarySearch", function () {
     let mockSourcifyChain: SourcifyChain;

--- a/services/server/test/unit/utils/contract-creation-util.spec.ts
+++ b/services/server/test/unit/utils/contract-creation-util.spec.ts
@@ -9,14 +9,11 @@ import sinon from "sinon";
 import { SourcifyChain } from "@ethereum-sourcify/lib-sourcify";
 import { findContractCreationTxByBinarySearch } from "../../../src/server/services/utils/contract-creation-util";
 
-// Tests that call the live creation-tx APIs (Blockscout, NodeReal, ...) live
-// in test/creation-tx-apis/ and run in the separate test-creation-tx-apis CI
-// job, so a provider outage doesn't fail test-server.
+// Tests hitting the live creation-tx APIs are in test/creation-tx-apis/.
 describe("contract creation util", function () {
   let sourcifyChainsMap: SourcifyChainMap;
 
-  // A dummy http://localhost/ RPC satisfies SourcifyChain's "at least one RPC"
-  // requirement without hitting the network.
+  // The dummy RPC satisfies SourcifyChain's "at least one RPC" requirement.
   before(async () => {
     const dummyRpcs = [{ rpc: "http://localhost/" }];
     sourcifyChainsMap = {


### PR DESCRIPTION
## Summary

- Move the `getCreatorTx` tests that call live third-party APIs (Blockscout, Routescan, Etherscan, Avalanche, VeChain, NodeReal, Nexus) from `test/unit/` into `services/server/test/creation-tx-apis/`, outside the `test-server` globs.
- Add a `test:creation-tx-apis` npm script and a new CircleCI job `test-creation-tx-apis` in both workflows. No other job requires it.
- The mocked tests (Etherscan API key handling, binary search) stay in the unit suite.

## Why

`test-server` has failed on every CI run since Aug 25 because NodeReal's `nr_getContractCreationTransaction` stopped returning the creation tx (the CI key gets a response with no `result.hash`; production BSC currently falls back to Etherscan). Any of the live providers in that loop can take CI hostage the same way — there's precedent in the file (chain 51 test commented out, live binary-search test skipped).

CircleCI reports one GitHub status per job, and staging has no required status checks, so after this change a provider outage shows up as a red `ci/circleci: test-creation-tx-apis` line on PRs while `test-server` stays green and meaningful. The live coverage still runs on every PR, so "the external service is really failing" remains visible.

## Notes

- `test-creation-tx-apis` will be red from day one: the NodeReal integration is genuinely broken. Someone with access to the NodeReal dashboard should check the key/plan.
- Etherscan and VeChain tests keep their existing skip on external PRs (`CIRCLE_PR_REPONAME`), and NodeReal keeps its skip when `NODEREAL_API_KEY` is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)