### PR TITLE
Remove blocksScanApi creation-tx fetcher

### DIFF
--- a/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
+++ b/packages/lib-sourcify/src/SourcifyChain/SourcifyChainTypes.ts
@@ -29,9 +29,6 @@ export interface FetchContractCreationTxMethods {
     type: 'mainnet' | 'testnet';
   };
   etherscanApi?: boolean;
-  blocksScanApi?: {
-    url: string;
-  };
   avalancheApi?: boolean;
   nexusApi?: {
     url: string;

--- a/services/server/src/server/services/utils/contract-creation-util.ts
+++ b/services/server/src/server/services/utils/contract-creation-util.ts
@@ -5,7 +5,6 @@ import { deriveEtherscanApiKey } from "./etherscan-util";
 
 const ETHERSCAN_API =
   "https://api.etherscan.io/v2/api?chainid=${CHAIN_ID}&module=contract&action=getcontractcreation&contractaddresses=${ADDRESS}&apikey=";
-const BLOCKSSCAN_SUFFIX = "api/accounts/${ADDRESS}";
 const BLOCKSCOUT_API_SUFFIX = "/api/v2/addresses/${ADDRESS}";
 const AVALANCHE_SUBNET_SUFFIX =
   "contracts/${ADDRESS}/transactions:getDeployment";
@@ -79,17 +78,6 @@ function getRoutescanApiContractCreatorFetcher(
   return getApiContractCreationFetcher(
     url,
     (response: any) => response?.result?.[0]?.txHash,
-  );
-}
-
-function getBlocksScanApiContractCreatorFetcher(
-  apiURL: string,
-): ContractCreationFetcher {
-  return getApiContractCreationFetcher(
-    apiURL + BLOCKSSCAN_SUFFIX,
-    (response: any) => {
-      if (response.fromTxn) return response.fromTxn as string;
-    },
   );
 }
 
@@ -293,15 +281,6 @@ export const getCreatorTx = async (
     }
   }
 
-  if (sourcifyChain.fetchContractCreationTxUsing?.blocksScanApi) {
-    const fetcher = getBlocksScanApiContractCreatorFetcher(
-      sourcifyChain.fetchContractCreationTxUsing?.blocksScanApi.url,
-    );
-    const result = await getCreatorTxUsingFetcher(fetcher, contractAddress);
-    if (result) {
-      return result;
-    }
-  }
   if (sourcifyChain.fetchContractCreationTxUsing?.nexusApi) {
     const fetcher = getNexusApiContractCreatorFetcher(
       sourcifyChain.fetchContractCreationTxUsing?.nexusApi.url,


### PR DESCRIPTION
## Summary

- Remove the `blocksScanApi` option from `FetchContractCreationTxMethods` in lib-sourcify and the matching fetcher / branch in the server's `getCreatorTx`.

## Why

The only chain that used `blocksScanApi` was XDC Apothem Testnet (51), pointing at `https://apothem.xdcscan.io/`. That endpoint is down (HTTP 521). The chain is auto-discovered by dRPC and Etherscan, and the Etherscan v2 API already returns its creation tx, so the manual override is being removed from `sourcifyeth/sourcify-chains` (companion PR linked in the comments) and this code path has no users left.

## Notes

- `blocksScanApi` is dropped from the lib-sourcify type, so a self-hosted `sourcify-chains.json` that still sets it will fail type-checking. Minor breaking change for lib-sourcify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)