### PR TITLE
test: remove the live ipfs.io dependency from monitor and server tests

### DIFF
--- a/services/monitor/test/Monitor.spec.ts
+++ b/services/monitor/test/Monitor.spec.ts
@@ -16,7 +16,11 @@ import {
 } from "@ethereum-sourcify/test-helpers";
 import type { ChildProcess } from "child_process";
 import storageContractArtifact from "./sources/Storage/1_Storage.json";
+import storageContractMetadata from "./sources/Storage/1_Storage.metadata.json";
 import nock from "nock";
+import fs from "fs";
+import path from "path";
+import { AuxdataStyle, decode } from "@ethereum-sourcify/bytecode-utils";
 import type { RpcObject } from "../src/types";
 import type { FetchRequestRPC } from "@ethereum-sourcify/lib-sourcify";
 
@@ -25,11 +29,51 @@ const HARDHAT_PORT = 8546;
 const HARDHAT_BLOCK_TIME_IN_SEC = 3;
 const MOCK_SOURCIFY_SERVER = "http://mocksourcifyserver.dev/server/";
 const MOCK_SIMILARITY_SERVER = "http://mocksimilarity.dev/server/";
+const MOCK_IPFS_ORIGIN = "http://mockipfs.dev";
+const MOCK_IPFS_GATEWAY = `${MOCK_IPFS_ORIGIN}/ipfs/`;
+const IPFS_URL_PREFIX = "dweb:/ipfs/";
 const localChain = {
   chainId: 1337,
   rpc: [`http://localhost:${HARDHAT_PORT}`],
   name: "Localhost Hardhat Network",
 };
+
+/**
+ * Mocks the IPFS gateway with nock so that the test does not depend on a live
+ * gateway. Serves the metadata of the Storage contract and its source file.
+ */
+function nockIpfsGatewayForStorageContract() {
+  const cborData = decode(
+    storageContractArtifact.bytecode,
+    AuxdataStyle.SOLIDITY,
+  );
+  const metadataCid = cborData.ipfs;
+  expect(metadataCid, "No IPFS CID in the test contract bytecode").to.be.a(
+    "string",
+  );
+
+  const sourceUrls: string[] = Object.values(storageContractMetadata.sources)[0]
+    .urls;
+  const sourceIpfsUrl = sourceUrls.find((url) =>
+    url.startsWith(IPFS_URL_PREFIX),
+  );
+  expect(sourceIpfsUrl, "No IPFS url in the test metadata").to.be.a("string");
+  const sourceCid = sourceIpfsUrl!.slice(IPFS_URL_PREFIX.length);
+  // The compiled source has no trailing newline. Remove it to match the
+  // keccak256 in the metadata.
+  const sourceContent = fs
+    .readFileSync(
+      path.join(__dirname, "sources", "Storage", "1_Storage.sol"),
+      "utf8",
+    )
+    .replace(/\n$/, "");
+
+  return nock(MOCK_IPFS_ORIGIN)
+    .get(`/ipfs/${metadataCid}`)
+    .reply(200, JSON.stringify(storageContractMetadata))
+    .get(`/ipfs/${sourceCid}`)
+    .reply(200, sourceContent);
+}
 
 describe("Monitor", function () {
   let sandbox: SinonSandbox;
@@ -63,6 +107,7 @@ describe("Monitor", function () {
     await stopHardhatNetwork(hardhatNodeProcess);
     if (monitor) monitor.stop();
     sandbox.restore();
+    nock.cleanAll();
   });
 
   describe("authenticateRpcs", () => {
@@ -204,8 +249,15 @@ describe("Monitor", function () {
   });
 
   it("should successfully catch a deployed contract, assemble, and send to Sourcify", async () => {
+    const ipfsScope = nockIpfsGatewayForStorageContract();
     monitor = new Monitor([localChain], {
       sourcifyServerURLs: [MOCK_SOURCIFY_SERVER],
+      decentralizedStorages: {
+        ipfs: {
+          enabled: true,
+          gateways: [MOCK_IPFS_GATEWAY],
+        },
+      },
       chainConfigs: {
         [localChain.chainId]: {
           startBlock: 0,
@@ -237,6 +289,8 @@ describe("Monitor", function () {
           nockInterceptor.isDone(),
           `Server ${MOCK_SOURCIFY_SERVER} not called`,
         ).to.be.true;
+        expect(ipfsScope.isDone(), "IPFS gateway not called for all files").to
+          .be.true;
         resolve();
       });
     });

--- a/services/server/src/server/services/VerificationService.ts
+++ b/services/server/src/server/services/VerificationService.ts
@@ -12,7 +12,10 @@ import type {
   EtherscanResult,
   AnyCompilation,
 } from "@ethereum-sourcify/lib-sourcify";
-import { Verification } from "@ethereum-sourcify/lib-sourcify";
+import {
+  SolidityMetadataContract,
+  Verification,
+} from "@ethereum-sourcify/lib-sourcify";
 import { getCreatorTx } from "./utils/contract-creation-util";
 import { ContractIsAlreadyBeingVerifiedError } from "../../common/errors/ContractIsAlreadyBeingVerifiedError";
 import logger from "../../common/logger";
@@ -154,6 +157,8 @@ export class VerificationService {
         // We can use the environment variable because it is overwritten by setLogLevel at server startup
         logLevel: process.env.NODE_LOG_LEVEL,
         sourcifyChainInstanceMap,
+        // Workers run in separate threads and do not share this global
+        ipfsGateway: SolidityMetadataContract.getGlobalIpfsGateway(),
         solcRepoPath: options.solcRepoPath,
         solJsonRepoPath: options.solJsonRepoPath,
         vyperRepoPath: options.vyperRepoPath,

--- a/services/server/src/server/services/workers/verificationWorker.ts
+++ b/services/server/src/server/services/workers/verificationWorker.ts
@@ -49,6 +49,12 @@ const initWorker = () => {
 
   setLogLevel(Piscina.workerData.logLevel || "info");
 
+  if (Piscina.workerData.ipfsGateway) {
+    SolidityMetadataContract.setGlobalIpfsGateway(
+      Piscina.workerData.ipfsGateway,
+    );
+  }
+
   const sourcifyChainInstanceMap = Piscina.workerData
     .sourcifyChainInstanceMap as { [chainId: string]: SourcifyChainInstance };
 

--- a/services/server/test/helpers/IpfsMockServer.ts
+++ b/services/server/test/helpers/IpfsMockServer.ts
@@ -1,0 +1,45 @@
+import http from "http";
+import type { AddressInfo } from "net";
+import path from "path";
+import { readFilesFromDirectory } from "./helpers";
+
+const IPFS_MOCK_DIR = path.join(__dirname, "..", "mocks", "ipfs");
+
+let mockServer: http.Server | undefined;
+let mockGatewayUrl: string | undefined;
+
+/**
+ * Starts a local HTTP server that serves the files in `test/mocks/ipfs`
+ * under `/ipfs/<cid>`. Returns the gateway url.
+ *
+ * The verification workers run in separate threads. nock only intercepts
+ * requests in the main thread, so a real server is necessary.
+ */
+export async function getIpfsMockGatewayUrl(): Promise<string> {
+  if (mockGatewayUrl) {
+    return mockGatewayUrl;
+  }
+
+  const mockContent = await readFilesFromDirectory(IPFS_MOCK_DIR);
+
+  mockServer = http.createServer((req, res) => {
+    const match = /^\/ipfs\/([^/?]+)/.exec(req.url || "");
+    const cid = match ? match[1] : "";
+    if (!Object.prototype.hasOwnProperty.call(mockContent, cid)) {
+      res.writeHead(404);
+      res.end("Not found");
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "text/plain" });
+    res.end(mockContent[cid]);
+  });
+  // Do not keep the process alive because of this server
+  mockServer.unref();
+
+  await new Promise<void>((resolve) =>
+    mockServer!.listen(0, "127.0.0.1", resolve),
+  );
+  const { port } = mockServer.address() as AddressInfo;
+  mockGatewayUrl = `http://127.0.0.1:${port}/ipfs/`;
+  return mockGatewayUrl;
+}

--- a/services/server/test/helpers/LocalChainFixture.ts
+++ b/services/server/test/helpers/LocalChainFixture.ts
@@ -1,14 +1,11 @@
 import path from "path";
 import fs from "fs";
 import type { DeploymentInfo } from "./helpers";
-import {
-  deployFromAbiAndBytecodeForCreatorTxHash,
-  readFilesFromDirectory,
-} from "./helpers";
+import { deployFromAbiAndBytecodeForCreatorTxHash } from "./helpers";
 import type { JsonRpcSigner } from "ethers";
 import { JsonRpcProvider, Network } from "ethers";
 import { LOCAL_CHAINS } from "../../src/sourcify-chains";
-import nock from "nock";
+import { getIpfsMockGatewayUrl } from "./IpfsMockServer";
 import storageContractArtifact from "../testcontracts/Storage/Storage.json";
 import storageContractMetadata from "../testcontracts/Storage/metadata.json";
 import storageContractMetadataModified from "../testcontracts/Storage/metadataModified.json";
@@ -19,7 +16,7 @@ import {
   stopHardhatNetwork,
 } from "@ethereum-sourcify/test-helpers";
 import { SolidityMetadataContract } from "@ethereum-sourcify/lib-sourcify";
-import type { Metadata } from "@ethereum-sourcify/lib-sourcify";
+import type { IpfsGateway, Metadata } from "@ethereum-sourcify/lib-sourcify";
 
 const storageContractSourcePath = path.join(
   __dirname,
@@ -73,6 +70,7 @@ export class LocalChainFixture {
   private _defaultContractTxIndex?: number;
 
   private hardhatNodeProcess?: ChildProcess;
+  private originalIpfsGateway?: IpfsGateway;
 
   // Getters for type safety
   // Can be safely accessed in "it" blocks
@@ -123,18 +121,12 @@ export class LocalChainFixture {
     this._port = options.port ?? HARDHAT_PORT;
 
     before(async () => {
-      // Init IPFS mock with all the necessary pinned files
-      const mockContent = await readFilesFromDirectory(
-        path.join(__dirname, "..", "mocks", "ipfs"),
-      );
-      for (const ipfsKey of Object.keys(mockContent)) {
-        nock(SolidityMetadataContract.getGlobalIpfsGateway().url || "")
-          .persist()
-          .get("/" + ipfsKey)
-          .reply(function () {
-            return [200, mockContent[ipfsKey]];
-          });
-      }
+      // Point the IPFS gateway of the main thread to the local mock server
+      this.originalIpfsGateway =
+        SolidityMetadataContract.getGlobalIpfsGateway();
+      SolidityMetadataContract.setGlobalIpfsGateway({
+        url: await getIpfsMockGatewayUrl(),
+      });
 
       this.hardhatNodeProcess = await startHardhatNetwork(this._port);
 
@@ -167,7 +159,9 @@ export class LocalChainFixture {
       if (this.hardhatNodeProcess) {
         await stopHardhatNetwork(this.hardhatNodeProcess);
       }
-      nock.cleanAll();
+      if (this.originalIpfsGateway) {
+        SolidityMetadataContract.setGlobalIpfsGateway(this.originalIpfsGateway);
+      }
     });
   }
 }

--- a/services/server/test/helpers/ServerFixture.ts
+++ b/services/server/test/helpers/ServerFixture.ts
@@ -13,6 +13,7 @@ import { VyperLocal } from "../../src/server/services/compiler/local/VyperLocal"
 import { FeLocal } from "../../src/server/services/compiler/local/FeLocal";
 import path from "path";
 import { testS3Bucket, testS3Path } from "./S3ClientMock";
+import { getIpfsMockGatewayUrl } from "./IpfsMockServer";
 import type { SourcifyChainMap } from "@ethereum-sourcify/lib-sourcify";
 
 export type ServerFixtureOptions = {
@@ -97,6 +98,10 @@ export class ServerFixture {
         replaceContract: true,
         sourcifyPrivateToken: "sourcify-test-token",
         logLevel: "debug",
+        libSourcifyConfig: {
+          // The verification workers fetch missing sources from this gateway
+          ipfsGateway: { url: await getIpfsMockGatewayUrl() },
+        },
       };
 
       this._server = new Server(


### PR DESCRIPTION
## Summary

The `test-monitor` and `test-server` CI jobs fetched files from the public `ipfs.io` gateway. The jobs failed when the gateway did not respond. This caused the CI failures in https://github.com/argotorg/sourcify/pull/2965 and in https://github.com/argotorg/sourcify/pull/2951. Those PRs do not change the code these jobs test.

- **Monitor test**: `nock` now serves the metadata and the source of the Storage contract. The CID comes from the CBOR data in the test bytecode.
- **Server tests**: a local HTTP server now serves `test/mocks/ipfs`. The verification workers run in separate threads, so `nock` cannot intercept their requests. The old `nock` mock in `LocalChainFixture` only applied to the main thread.
- **Server**: `VerificationService` now passes the configured IPFS gateway to the verification workers. Before this change, the workers always used the default gateway and ignored `IPFS_GATEWAY`.

## Notes

- All monitor tests pass locally without network access.
- After this PR is on `staging`, the Renovate PR https://github.com/argotorg/sourcify/pull/2965 needs a rebase to get a green CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Te62UX9zYT5PH8qovoKfV

---
_Generated by [Claude Code](https://claude.ai/code/session_017Te62UX9zYT5PH8qovoKfV)_